### PR TITLE
feat(python): add hibot SDK package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-build: build-component build-api build-eva build-observe
+build: build-component build-api build-eva build-observe build-hibot
 
 build-component:
 	uv build --package hiagent-components
@@ -11,3 +11,6 @@ build-eva:
 
 build-observe:
 	uv build --package hiagent-observe
+
+build-hibot:
+	uv build --package hibot

--- a/libs/hibot/README.md
+++ b/libs/hibot/README.md
@@ -1,0 +1,182 @@
+# Hibot Python SDK
+
+Python client for the Hibot Managed Agent platform. Behaviorally aligned 1:1
+with the Go SDK in `hiagent-go-sdk/hibot` — same TOP routing, same VOLC v4
+signing, same SSE event normalization, same default-environment + peer
+injection semantics.
+
+> Distribution name: `hibot` (PyPI). Top-level import: `hibot`.
+>
+> Requires **Python 3.10+**, depends on `httpx>=0.28.1`.
+
+---
+
+## Install
+
+```bash
+# editable / dev (recommended for source checkout):
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+
+# or as a wheel:
+pip install hibot
+```
+
+## Quick start
+
+```python
+import hibot
+
+cfg = hibot.Config(
+    endpoint="https://open.volcengineapi.com",
+    access_key="AKLT...",
+    secret_key="...",
+    workspace_id="WS-12345",
+)
+
+with hibot.Hibot(cfg) as client:
+    # 1. Pick a base model (no Provider/Type filter ⇒ first match)
+    model = client.v1.models.get(hibot.V1ModelGetParams(
+        model_name="doubao-seed-2.0-pro-260215",
+    ))
+
+    # 2. Create an agent (default Environment auto-selected)
+    agent = client.v1.agents.create(hibot.V1AgentNewParams(
+        name="weather-bot",
+        system="You are a weather assistant.",
+        model=hibot.V1ManagedAgentModelConfigParams(id=model.id),
+    ))
+
+    # 3. Open a session (Peer auto-injected: webchat / system / agent_id)
+    session = client.v1.sessions.create(
+        hibot.V1SessionNewParams(agent_id=agent.id)
+    )
+
+    # 4a. Streaming chat
+    with client.v1.sessions.chat_streaming(
+        session.id,
+        hibot.V1SessionChatParams(input="What's the weather?"),
+    ) as stream:
+        for event in stream:
+            if event.type == "delta":
+                print(event.delta.text, end="", flush=True)
+            elif event.type == "completed":
+                print()  # newline at end
+        final = stream.final_message()
+
+    # 4b. Or block until completion
+    msg = client.v1.sessions.chat(
+        session.id,
+        hibot.V1SessionChatParams(input="Same question."),
+    )
+    print(msg.content)
+```
+
+## Public surface
+
+Top-level (`hibot`):
+
+| Symbol                        | Description                                                |
+| ----------------------------- | ---------------------------------------------------------- |
+| `Hibot` / `Client`            | Main SDK client (alias)                                    |
+| `Config`                      | Endpoint + AK/SK + WorkspaceID + region/services overrides |
+| `APIError`                    | Raised on non-2xx or non-empty `ResponseMetadata.Error`    |
+| `V1*` types                   | All resource & param dataclasses (re-exported from `v1`)   |
+| `BASE_MODELS` / `BASE_MODEL_*`| Built-in aigw model catalog & constants                    |
+
+Resource services live under `client.v1.*`:
+
+- `client.v1.uploads` — `upload_blob` (routes to `/up` subpath via `up` service)
+- `client.v1.environments` — `create / list / get / update / delete / default`
+- `client.v1.models` — `get / list / create / update / delete / list_providers / list_model_providers / get_model_provider / get_model_provider_credential_schema`
+- `client.v1.prompts` — `create / list / update / delete`
+- `client.v1.resources` — `create / list / update / delete / get_by_name / batch_get` (+ nested `client.v1.resources.directories`)
+- `client.v1.mcps` — `create / list / get / update / delete / test_connection / resolve`
+- `client.v1.skills` — `create / list / get / update / delete / list_versions / resolve_version`
+- `client.v1.agents` — `create / list / get / batch_get / update / delete`
+- `client.v1.sessions` — `create / list / get / get_by_key / archive / delete / list_messages / get_message / inject_message / chat / chat_streaming`
+
+## Routing & versioning
+
+| Domain         | Service (default)  | Version       |
+| -------------- | ------------------ | ------------- |
+| CRUD           | `hibot-server`     | `2026-04-23`  |
+| Streaming chat | `hibot-gateway`    | `2026-05-11`  |
+| Models         | `aigw`             | `2023-08-01`  |
+| Uploads        | `up` (under `/up`) | `2022-01-01`  |
+
+All four service identifiers can be overridden on `Config` for private
+deployments (`server_service` / `gateway_service` / `model_service` /
+`up_service`).
+
+The SDK injects `WorkspaceID` only at the **top level** of each Action body
+(never inside `Payload`), exactly mirroring the Go SDK.
+
+## Stream events
+
+`V1SessionChatStream` normalizes the gateway’s several event-name dialects
+(message.chunk / message_delta / run_completed / message.failed / run_failed /
+tool_started / tool_completed / …) into the canonical three-state set:
+
+```
+delta            — incremental token chunk; access via event.delta.text
+completed        — final V1Message; access via event.message or stream.final_message()
+failed           — populated event.error.code / event.error.message
+tool_start       — tool invocation began
+tool_complete    — tool invocation finished
+approval_request / approval_responded / run_cancelling / run_cancelled — passthrough
+```
+
+Two helpers are available on the stream:
+
+- `accumulate()` — drains the stream, concatenates all `delta.text`, returns the
+  final `V1Message` (server-supplied content takes precedence).
+- `final_message()` — returns the last `completed` message or raises if none.
+
+## Failure semantics
+
+`Config.__post_init__` performs **fail-fast** validation: missing
+`endpoint` / `access_key` / `secret_key` / `workspace_id` raises immediately.
+
+Service methods reject empty required identifiers (e.g. `agent_id`, `session_id`)
+the same way the Go SDK does.
+
+## Field alignment with Go SDK
+
+The wire-format JSON schema is identical: response classes deserialize from
+PascalCase keys (e.g. `ID`, `WorkspaceID`, `CreatedAt`). Notable mappings that
+deviate from a literal field name:
+
+| Python attribute       | JSON key on the wire                       |
+| ---------------------- | ------------------------------------------ |
+| `V1MCP.endpoint`       | `URL` (server stores as URL)               |
+| `V1Prompt.content`     | `SystemPrompt` (the action payload field)  |
+| `V1ManagedAgentSkillToolParams.skill_version_id` → `Skills[].ID` (binding refs the version) |
+
+Skill bindings use the **version ID** in the `Skills[].ID` slot — pass the
+`SkillVersion.ID` from `client.v1.skills.list_versions` / `resolve_version`.
+
+## Running tests
+
+```bash
+pytest -q
+```
+
+Tests are completely offline — they use `httpx.MockTransport` to inspect
+URL/Action/Version/Authorization headers and request bodies, plus simulated
+SSE payloads to exercise the chat stream.
+
+## Differences from the Go SDK
+
+The Python SDK aims for behavioural parity but is implemented as a single
+synchronous client (no goroutine-style ctx). Other notable differences:
+
+- **No `context.Context`.** `httpx.Client.timeout` (set on `Config.timeout`)
+  governs total request time. Streaming chat disables the per-call timeout
+  (parity with Go's `DoStream`).
+- **dataclasses, not pydantic.** Result classes use Python `dataclass` with
+  field metadata for JSON name mapping; param classes use `dataclass` with
+  snake_case Python attributes. (See `hibot/v1/types.py`.)
+- **No async client** is provided in this MVP. The `async_http_client` slot
+  on `Config` is reserved for future use.

--- a/libs/hibot/hibot/__init__.py
+++ b/libs/hibot/hibot/__init__.py
@@ -1,0 +1,84 @@
+"""Hibot Managed Agent Python SDK.
+
+Public surface: :class:`Hibot` / :class:`Client` constructors, :class:`Config`,
+:class:`APIError`, plus the entire :mod:`hibot.v1` namespace re-exported
+under the ``V1*`` prefix for convenience::
+
+    import hibot
+
+    cfg = hibot.Config(
+        endpoint="https://open.volcengineapi.com",
+        access_key="AK",
+        secret_key="SK",
+        workspace_id="WS123",
+    )
+    with hibot.Hibot(cfg) as client:
+        agents = client.v1.agents.list()
+"""
+
+from __future__ import annotations
+
+from . import v1
+from ._config import Config
+from ._response import APIError
+from ._version import (
+    AIGW_SERVICE,
+    CHAT_VERSION,
+    DEFAULT_REGION,
+    GATEWAY_SERVICE,
+    MODEL_VERSION,
+    SERVER_SERVICE,
+    SERVER_VERSION,
+    UP_SERVICE,
+    UP_VERSION,
+)
+from .client import Client, Hibot
+from .v1 import (  # noqa: F401 — re-export public types
+    BASE_MODEL_PROVIDER_BYTEPLUS,
+    BASE_MODEL_PROVIDER_OPENAI,
+    BASE_MODEL_PROVIDER_VOLCENGINE,
+    BASE_MODEL_PROVIDER_VOLCENGINE_AICC,
+    BASE_MODEL_TYPE_AUDIO,
+    BASE_MODEL_TYPE_EMBEDDINGS,
+    BASE_MODEL_TYPE_RERANKING,
+    BASE_MODEL_TYPE_TEXT_GENERATION,
+    BASE_MODEL_TYPE_VISION,
+    BASE_MODELS,
+    Services,
+    V1Client,
+    V1SessionChatStream,
+)
+from .v1.types import *  # noqa: F401,F403
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "Hibot",
+    "Client",
+    "Config",
+    "APIError",
+    "v1",
+    "Services",
+    "V1Client",
+    "V1SessionChatStream",
+    "BASE_MODELS",
+    "BASE_MODEL_TYPE_TEXT_GENERATION",
+    "BASE_MODEL_TYPE_EMBEDDINGS",
+    "BASE_MODEL_TYPE_VISION",
+    "BASE_MODEL_TYPE_AUDIO",
+    "BASE_MODEL_TYPE_RERANKING",
+    "BASE_MODEL_PROVIDER_VOLCENGINE",
+    "BASE_MODEL_PROVIDER_BYTEPLUS",
+    "BASE_MODEL_PROVIDER_VOLCENGINE_AICC",
+    "BASE_MODEL_PROVIDER_OPENAI",
+    "DEFAULT_REGION",
+    "SERVER_SERVICE",
+    "GATEWAY_SERVICE",
+    "AIGW_SERVICE",
+    "UP_SERVICE",
+    "SERVER_VERSION",
+    "CHAT_VERSION",
+    "MODEL_VERSION",
+    "UP_VERSION",
+    "__version__",
+]

--- a/libs/hibot/hibot/_config.py
+++ b/libs/hibot/hibot/_config.py
@@ -1,0 +1,46 @@
+"""SDK Config (mirrors go/hibot/config.go)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from . import _version as _v
+
+
+@dataclass
+class Config:
+    endpoint: str
+    access_key: str
+    secret_key: str
+    workspace_id: str
+    region: str = _v.DEFAULT_REGION
+    server_service: str = _v.SERVER_SERVICE
+    gateway_service: str = _v.GATEWAY_SERVICE
+    model_service: str = _v.AIGW_SERVICE
+    up_service: str = _v.UP_SERVICE
+    timeout: float = 30.0
+    # Optional pre-built httpx.Client / httpx.AsyncClient — leave None to let
+    # SDK build defaults internally.
+    http_client: Optional[object] = None
+    async_http_client: Optional[object] = None
+
+    def __post_init__(self) -> None:
+        self.endpoint = (self.endpoint or "").strip()
+        self.access_key = (self.access_key or "").strip()
+        self.secret_key = (self.secret_key or "").strip()
+        self.workspace_id = (self.workspace_id or "").strip()
+        self.region = (self.region or "").strip() or _v.DEFAULT_REGION
+        self.server_service = (self.server_service or "").strip() or _v.SERVER_SERVICE
+        self.gateway_service = (self.gateway_service or "").strip() or _v.GATEWAY_SERVICE
+        self.model_service = (self.model_service or "").strip() or _v.AIGW_SERVICE
+        self.up_service = (self.up_service or "").strip() or _v.UP_SERVICE
+
+        if not self.endpoint:
+            raise ValueError("hibot: endpoint is required")
+        if not self.access_key:
+            raise ValueError("hibot: access key is required")
+        if not self.secret_key:
+            raise ValueError("hibot: secret key is required")
+        if not self.workspace_id:
+            raise ValueError("hibot: workspace id is required")

--- a/libs/hibot/hibot/_request.py
+++ b/libs/hibot/hibot/_request.py
@@ -1,0 +1,183 @@
+"""HTTP request layer for TOP Action calls (mirrors go/hibot/internal/request)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, Mapping, Optional
+from urllib.parse import urlencode, urlsplit, urlunsplit
+
+import httpx
+
+from ._config import Config
+from ._response import APIError, decode_top
+from ._signer import sign_request
+
+
+@dataclass
+class Action:
+    service: str
+    version: str
+    action: str
+    body: Any = None
+    stream: bool = False
+
+
+class Requester:
+    """Synchronous TOP request executor shared by all V1 resource services."""
+
+    def __init__(self, config: Config) -> None:
+        self._cfg = config
+        self._client: Optional[httpx.Client] = None
+        if config.http_client is not None and isinstance(config.http_client, httpx.Client):
+            self._client = config.http_client
+            self._owns_client = False
+        else:
+            self._client = httpx.Client(timeout=config.timeout)
+            self._owns_client = True
+
+    @property
+    def config(self) -> Config:
+        return self._cfg
+
+    def close(self) -> None:
+        if self._owns_client and self._client is not None:
+            self._client.close()
+            self._client = None
+
+    # -------- public ops --------
+
+    def do_action(self, action: Action) -> Optional[Any]:
+        body_bytes = self._marshal_body(action.body)
+        url, headers = self._build_request(action, body_bytes, "application/json", None)
+        resp = self._client.request("POST", url, content=body_bytes, headers=headers)
+        return decode_top(resp.status_code, resp.content)
+
+    def do_raw_action(
+        self,
+        action: Action,
+        body: bytes,
+        content_type: str,
+        query: Optional[Mapping[str, str]] = None,
+    ) -> Optional[Any]:
+        url, headers = self._build_request(action, body or b"", content_type or "application/octet-stream", query)
+        resp = self._client.request("POST", url, content=body or b"", headers=headers)
+        return decode_top(resp.status_code, resp.content)
+
+    def stream_action(self, action: Action) -> "_StreamResponse":
+        body_bytes = self._marshal_body(action.body)
+        action.stream = True
+        url, headers = self._build_request(action, body_bytes, "application/json", None)
+        # SSE streams may run beyond the default timeout.
+        ctx = self._client.stream("POST", url, content=body_bytes, headers=headers, timeout=None)
+        resp = ctx.__enter__()
+        return _StreamResponse(ctx, resp)
+
+    # -------- internals --------
+
+    def _marshal_body(self, body: Any) -> bytes:
+        m = _to_map(body)
+        if self._cfg.workspace_id and _workspace_missing(m.get("WorkspaceID")):
+            m["WorkspaceID"] = self._cfg.workspace_id
+        return json.dumps(m, separators=(",", ":")).encode("utf-8")
+
+    def _build_request(
+        self,
+        action: Action,
+        body: bytes,
+        content_type: str,
+        query: Optional[Mapping[str, str]],
+    ):
+        # Compose URL: TOP gateway hosts the up service under /up
+        # subpath; other services share the root path.
+        parts = urlsplit(self._cfg.endpoint)
+        path = parts.path or ""
+        if action.service == self._cfg.up_service or action.service == "up":
+            path = path.rstrip("/") + "/up"
+        q = {}
+        # Preserve any pre-existing query on the endpoint (rare).
+        if parts.query:
+            from urllib.parse import parse_qsl
+            q.update(dict(parse_qsl(parts.query, keep_blank_values=True)))
+        q["Action"] = action.action
+        q["Version"] = action.version
+        if query:
+            q.update(query)
+        encoded = urlencode(q)
+        url = urlunsplit((parts.scheme, parts.netloc, path, encoded, ""))
+
+        headers: Dict[str, str] = {
+            "Content-Type": content_type,
+            "X-Top-Service": action.service,
+        }
+        if action.stream:
+            headers["Accept"] = "text/event-stream"
+
+        signed = sign_request(
+            method="POST",
+            url=url,
+            headers=headers,
+            body=body,
+            access_key=self._cfg.access_key,
+            secret_key=self._cfg.secret_key,
+            region=self._cfg.region,
+            service=action.service,
+        )
+        return url, signed
+
+
+class _StreamResponse:
+    """Wrapper that owns the httpx stream context manager."""
+
+    def __init__(self, ctx, resp: httpx.Response) -> None:
+        self._ctx = ctx
+        self._resp = resp
+        self._closed = False
+
+    @property
+    def status_code(self) -> int:
+        return self._resp.status_code
+
+    def read_all(self) -> bytes:
+        return self._resp.read()
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        return self._resp.iter_raw()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._ctx.__exit__(None, None, None)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _to_map(v: Any) -> Dict[str, Any]:
+    if v is None:
+        return {}
+    if isinstance(v, dict):
+        # Ensure we deep-copy via JSON so callers don't get aliasing of injected keys.
+        return json.loads(json.dumps(v, default=_default_encoder))
+    # Encode arbitrary objects via JSON serializer (dataclasses etc.)
+    return json.loads(json.dumps(v, default=_default_encoder))
+
+
+def _default_encoder(o: Any) -> Any:
+    if hasattr(o, "to_dict") and callable(o.to_dict):
+        return o.to_dict()
+    if hasattr(o, "__dict__"):
+        return {k: v for k, v in o.__dict__.items() if not k.startswith("_") and v is not None}
+    raise TypeError(f"hibot: cannot encode object of type {type(o).__name__}")
+
+
+def _workspace_missing(v: Any) -> bool:
+    if v is None:
+        return True
+    if isinstance(v, str):
+        return v == ""
+    return False
+
+
+__all__ = ["Requester", "Action", "APIError"]

--- a/libs/hibot/hibot/_response.py
+++ b/libs/hibot/hibot/_response.py
@@ -1,0 +1,74 @@
+"""TOP envelope decoding & APIError (mirrors go/hibot/internal/response)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+
+class APIError(Exception):
+    """Raised on Hibot TOP API errors (non-2xx response or non-empty Error)."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        request_id: str = "",
+        code: str = "",
+        message: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self.request_id = request_id
+        self.code = code
+        self.message = message
+        super().__init__(self._fmt())
+
+    def _fmt(self) -> str:
+        if not self.code and not self.message:
+            return f"hibot: api error status={self.status_code} request_id={self.request_id}"
+        return (
+            f"hibot: api error status={self.status_code} "
+            f"request_id={self.request_id} code={self.code} message={self.message}"
+        )
+
+
+def decode_top(status_code: int, body: bytes) -> Optional[Any]:
+    """Decode a TOP envelope. Returns ``Result`` (json-decoded) or None.
+
+    Raises APIError on non-2xx status or non-empty ``ResponseMetadata.Error``.
+    """
+    try:
+        env = json.loads(body) if body else {}
+    except (ValueError, TypeError):
+        if status_code >= 400:
+            raise APIError(status_code=status_code, message=body.decode("utf-8", "replace"))
+        raise
+
+    if not isinstance(env, dict):
+        env = {}
+    metadata = env.get("ResponseMetadata") or {}
+    request_id = metadata.get("RequestId", "") or metadata.get("RequestID", "")
+    err = metadata.get("Error")
+
+    if status_code >= 400 or err:
+        code = ""
+        message = ""
+        if isinstance(err, dict):
+            code = err.get("Code", "") or ""
+            message = err.get("Message", "") or ""
+        elif status_code >= 400 and not env:
+            message = body.decode("utf-8", "replace") if body else ""
+        raise APIError(
+            status_code=status_code,
+            request_id=request_id,
+            code=code,
+            message=message,
+        )
+
+    result = env.get("Result")
+    if result is None:
+        return None
+    return result
+
+
+__all__ = ["APIError", "decode_top"]

--- a/libs/hibot/hibot/_signer.py
+++ b/libs/hibot/hibot/_signer.py
@@ -1,0 +1,141 @@
+"""TOP / VOLC v4 request signer.
+
+Mirrors github.com/volcengine/volc-sdk-golang/base.Credentials.Sign — algorithm
+"HMAC-SHA256" with credential scope ``<date>/<region>/<service>/request``.
+
+The reference Python implementation lives in
+``github.com/volcengine/volc-sdk-python``; the algorithm is identical to the
+public AWS Signature V4 with the algorithm string changed from
+``AWS4-HMAC-SHA256`` to ``HMAC-SHA256`` (no ``AWS4`` prefix on the signing
+key derivation, no ``aws4_request`` terminator).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import hmac
+from typing import Dict, Iterable, Mapping, Optional, Tuple
+from urllib.parse import quote, urlsplit
+
+ALGORITHM = "HMAC-SHA256"
+SIGNED_HEADERS_INCLUDE = ("content-type", "host", "x-content-sha256", "x-date")
+
+
+def _utcnow() -> _dt.datetime:
+    return _dt.datetime.now(_dt.timezone.utc)
+
+
+def _hmac_sha256(key: bytes, msg: str) -> bytes:
+    return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _canonical_query(query: str) -> str:
+    if not query:
+        return ""
+    pairs = []
+    for raw in query.split("&"):
+        if not raw:
+            continue
+        if "=" in raw:
+            k, _, v = raw.partition("=")
+        else:
+            k, v = raw, ""
+        # Re-encode keys & values strictly per RFC 3986 (do not encode "~").
+        pairs.append((quote(k, safe="-_.~"), quote(v, safe="-_.~")))
+    pairs.sort()
+    return "&".join(f"{k}={v}" for k, v in pairs)
+
+
+def _canonical_uri(path: str) -> str:
+    if not path:
+        return "/"
+    # Each segment must be percent-encoded once. Slashes are preserved.
+    segments = path.split("/")
+    encoded = [quote(seg, safe="-_.~") for seg in segments]
+    return "/".join(encoded)
+
+
+def _canonical_headers(headers: Mapping[str, str], include: Iterable[str]) -> Tuple[str, str]:
+    lower = {k.lower(): v for k, v in headers.items()}
+    keys = sorted(k for k in include if k in lower)
+    canonical = "".join(f"{k}:{lower[k].strip()}\n" for k in keys)
+    signed = ";".join(keys)
+    return canonical, signed
+
+
+def sign_request(
+    *,
+    method: str,
+    url: str,
+    headers: Dict[str, str],
+    body: bytes,
+    access_key: str,
+    secret_key: str,
+    region: str,
+    service: str,
+    now: Optional[_dt.datetime] = None,
+) -> Dict[str, str]:
+    """Sign an HTTP request in-place style (returns a new headers dict).
+
+    The returned dict contains all original headers plus ``Host``, ``X-Date``,
+    ``X-Content-Sha256`` and ``Authorization``. Callers should set this as the
+    request's headers.
+    """
+    if now is None:
+        now = _utcnow()
+    amzdate = now.strftime("%Y%m%dT%H%M%SZ")
+    datestamp = now.strftime("%Y%m%d")
+
+    parts = urlsplit(url)
+    host = parts.netloc
+    path = parts.path or "/"
+    query = parts.query
+
+    body = body or b""
+    payload_hash = _sha256_hex(body)
+
+    out_headers = dict(headers)
+    out_headers.setdefault("Host", host)
+    out_headers["X-Date"] = amzdate
+    out_headers["X-Content-Sha256"] = payload_hash
+
+    canonical_headers, signed_headers = _canonical_headers(out_headers, SIGNED_HEADERS_INCLUDE)
+    canonical_request = "\n".join([
+        method.upper(),
+        _canonical_uri(path),
+        _canonical_query(query),
+        canonical_headers,
+        signed_headers,
+        payload_hash,
+    ])
+
+    credential_scope = f"{datestamp}/{region}/{service}/request"
+    string_to_sign = "\n".join([
+        ALGORITHM,
+        amzdate,
+        credential_scope,
+        _sha256_hex(canonical_request.encode("utf-8")),
+    ])
+
+    k_date = _hmac_sha256(secret_key.encode("utf-8"), datestamp)
+    k_region = _hmac_sha256(k_date, region)
+    k_service = _hmac_sha256(k_region, service)
+    k_signing = _hmac_sha256(k_service, "request")
+    signature = hmac.new(k_signing, string_to_sign.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    authorization = (
+        f"{ALGORITHM} "
+        f"Credential={access_key}/{credential_scope}, "
+        f"SignedHeaders={signed_headers}, "
+        f"Signature={signature}"
+    )
+    out_headers["Authorization"] = authorization
+    return out_headers
+
+
+__all__ = ["sign_request", "ALGORITHM"]

--- a/libs/hibot/hibot/_sse.py
+++ b/libs/hibot/hibot/_sse.py
@@ -1,0 +1,109 @@
+"""SSE decoder (mirrors go/hibot/internal/stream/sse.go)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, List
+
+
+@dataclass
+class Frame:
+    event: str = ""
+    data: str = ""
+
+
+def iter_frames(lines: Iterable[str]) -> Iterator[Frame]:
+    """Decode SSE frames from a sequence of *already-line-split* strings.
+
+    The input lines should NOT contain the trailing ``\n``/``\r\n``.
+    A blank line terminates a frame (empty frames are skipped).
+    """
+    event = ""
+    data: List[str] = []
+    for raw in lines:
+        line = raw.rstrip("\r\n")
+        if line == "":
+            if event == "" and not data:
+                continue
+            yield Frame(event=event, data="\n".join(data))
+            event = ""
+            data = []
+            continue
+        if line.startswith(":"):
+            continue
+        if line.startswith("event:"):
+            event = line[len("event:"):].strip()
+            continue
+        if line.startswith("data:"):
+            value = line[len("data:"):]
+            # SSE: a single leading space is part of the spec separator.
+            if value.startswith(" "):
+                value = value[1:]
+            data.append(value.strip())
+            continue
+        # Unknown field — skip per spec.
+    if event != "" or data:
+        yield Frame(event=event, data="\n".join(data))
+
+
+class ByteStreamDecoder:
+    """Incremental decoder fed with bytes chunks from an HTTP stream."""
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+        self._event = ""
+        self._data: List[str] = []
+        self._frames: List[Frame] = []
+
+    def feed(self, chunk: bytes) -> None:
+        if not chunk:
+            return
+        self._buf.extend(chunk)
+        while True:
+            idx = self._buf.find(b"\n")
+            if idx < 0:
+                break
+            raw = bytes(self._buf[:idx])
+            del self._buf[: idx + 1]
+            line = raw.decode("utf-8", "replace").rstrip("\r")
+            self._handle_line(line)
+
+    def close(self) -> None:
+        # Flush any buffered partial line.
+        if self._buf:
+            line = bytes(self._buf).decode("utf-8", "replace").rstrip("\r\n")
+            self._buf.clear()
+            self._handle_line(line)
+        # Flush any remaining frame without a terminating blank line.
+        if self._event != "" or self._data:
+            self._frames.append(Frame(event=self._event, data="\n".join(self._data)))
+            self._event = ""
+            self._data = []
+
+    def _handle_line(self, line: str) -> None:
+        if line == "":
+            if self._event == "" and not self._data:
+                return
+            self._frames.append(Frame(event=self._event, data="\n".join(self._data)))
+            self._event = ""
+            self._data = []
+            return
+        if line.startswith(":"):
+            return
+        if line.startswith("event:"):
+            self._event = line[len("event:"):].strip()
+            return
+        if line.startswith("data:"):
+            value = line[len("data:"):]
+            if value.startswith(" "):
+                value = value[1:]
+            self._data.append(value.strip())
+            return
+
+    def pop_frames(self) -> List[Frame]:
+        out = self._frames
+        self._frames = []
+        return out
+
+
+__all__ = ["Frame", "iter_frames", "ByteStreamDecoder"]

--- a/libs/hibot/hibot/_version.py
+++ b/libs/hibot/hibot/_version.py
@@ -1,0 +1,18 @@
+"""Internal version & service constants mirroring go/hibot/internal/version."""
+
+DEFAULT_REGION = "cn-north-1"
+
+SERVER_SERVICE = "hibot-server"
+GATEWAY_SERVICE = "hibot-gateway"
+# AIGW DestService: the TOP gateway registers model/provider
+# Actions under this exact service name; "aigw-server" returns InvalidAction.
+AIGW_SERVICE = "aigw"
+UP_SERVICE = "up"
+
+V1 = "v1"
+
+# TOP-registered API Versions (YYYY-MM-DD).
+SERVER_VERSION = "2026-04-23"
+CHAT_VERSION = "2026-05-11"
+MODEL_VERSION = "2023-08-01"
+UP_VERSION = "2022-01-01"

--- a/libs/hibot/hibot/client.py
+++ b/libs/hibot/hibot/client.py
@@ -1,0 +1,48 @@
+"""Top-level Hibot client (mirrors go/hibot/hibot.go + v1/client.go)."""
+
+from __future__ import annotations
+
+from ._config import Config
+from ._request import Requester
+from .v1 import Services, V1Client
+
+
+class Client:
+    """Synchronous Hibot SDK client.
+
+    Acquire via :class:`Hibot` (alias) or directly with a :class:`Config`::
+
+        client = hibot.Hibot(config)
+        agents = client.v1.agents.list()
+    """
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+        self._requester = Requester(config)
+        services = Services(
+            server=config.server_service,
+            gateway=config.gateway_service,
+            model=config.model_service,
+            up=config.up_service,
+        )
+        self.v1 = V1Client(self._requester, services)
+
+    @property
+    def config(self) -> Config:
+        return self._config
+
+    def close(self) -> None:
+        self._requester.close()
+
+    def __enter__(self) -> "Client":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+# Alias requested by the spec (Go's *hibot.Hibot ~ Python's Hibot()).
+Hibot = Client
+
+
+__all__ = ["Client", "Hibot"]

--- a/libs/hibot/hibot/v1/__init__.py
+++ b/libs/hibot/hibot/v1/__init__.py
@@ -1,0 +1,59 @@
+"""V1 namespace exports."""
+
+from __future__ import annotations
+
+from ._client import Services, V1Client
+from .agents import AgentsService
+from .base_models import (
+    BASE_MODEL_PROVIDER_BYTEPLUS,
+    BASE_MODEL_PROVIDER_OPENAI,
+    BASE_MODEL_PROVIDER_VOLCENGINE,
+    BASE_MODEL_PROVIDER_VOLCENGINE_AICC,
+    BASE_MODEL_TYPE_AUDIO,
+    BASE_MODEL_TYPE_EMBEDDINGS,
+    BASE_MODEL_TYPE_RERANKING,
+    BASE_MODEL_TYPE_TEXT_GENERATION,
+    BASE_MODEL_TYPE_VISION,
+    BASE_MODELS,
+)
+from .environments import EnvironmentsService
+from .mcps import MCPsService
+from .models import ModelsService
+from .prompts import PromptsService
+from .resources import DirectoriesService, ResourcesService
+from .sessions import SessionsService
+from .skills import SkillsService
+from .stream import V1SessionChatStream, decode_chat_event, normalize_chat_event_name
+from .types import *  # noqa: F401,F403
+from .uploads import UploadsService
+
+__all__ = [
+    "V1Client",
+    "Services",
+    # services
+    "AgentsService",
+    "EnvironmentsService",
+    "MCPsService",
+    "ModelsService",
+    "PromptsService",
+    "ResourcesService",
+    "DirectoriesService",
+    "SessionsService",
+    "SkillsService",
+    "UploadsService",
+    # streaming
+    "V1SessionChatStream",
+    "decode_chat_event",
+    "normalize_chat_event_name",
+    # base models
+    "BASE_MODELS",
+    "BASE_MODEL_TYPE_TEXT_GENERATION",
+    "BASE_MODEL_TYPE_EMBEDDINGS",
+    "BASE_MODEL_TYPE_VISION",
+    "BASE_MODEL_TYPE_AUDIO",
+    "BASE_MODEL_TYPE_RERANKING",
+    "BASE_MODEL_PROVIDER_VOLCENGINE",
+    "BASE_MODEL_PROVIDER_BYTEPLUS",
+    "BASE_MODEL_PROVIDER_VOLCENGINE_AICC",
+    "BASE_MODEL_PROVIDER_OPENAI",
+]

--- a/libs/hibot/hibot/v1/_client.py
+++ b/libs/hibot/hibot/v1/_client.py
@@ -1,0 +1,48 @@
+"""V1 client (mirrors go/hibot/v1/client.go)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .._request import Requester
+
+
+@dataclass
+class Services:
+    server: str
+    gateway: str
+    model: str
+    up: str
+
+
+class V1Client:
+    """Container for all V1 resource services."""
+
+    def __init__(self, requester: Requester, services: Services) -> None:
+        self.requester = requester
+        self.services = services
+
+        # Lazy import to avoid circular references.
+        from .agents import AgentsService
+        from .environments import EnvironmentsService
+        from .mcps import MCPsService
+        from .models import ModelsService
+        from .prompts import PromptsService
+        from .resources import ResourcesService
+        from .sessions import SessionsService
+        from .skills import SkillsService
+        from .uploads import UploadsService
+
+        self.uploads = UploadsService(self)
+        self.environments = EnvironmentsService(self)
+        self.models = ModelsService(self)
+        self.prompts = PromptsService(self)
+        self.resources = ResourcesService(self)
+        self.mcps = MCPsService(self)
+        self.skills = SkillsService(self)
+        self.agents = AgentsService(self)
+        self.sessions = SessionsService(self)
+
+    @property
+    def workspace_id(self) -> str:
+        return self.requester.config.workspace_id

--- a/libs/hibot/hibot/v1/_helpers.py
+++ b/libs/hibot/hibot/v1/_helpers.py
@@ -1,0 +1,105 @@
+"""Internal helpers shared by V1 services."""
+
+from __future__ import annotations
+
+from dataclasses import fields, is_dataclass
+from typing import Any, Dict, List, Optional, Type, TypeVar
+
+T = TypeVar("T")
+
+
+def from_dict(cls: Type[T], data: Any) -> Optional[T]:
+    """Build a dataclass from a server-side dict (PascalCase keys)."""
+    if data is None:
+        return None
+    if isinstance(data, cls):
+        return data
+    if not isinstance(data, dict):
+        return None
+    if not is_dataclass(cls):
+        raise TypeError(f"from_dict requires a dataclass; got {cls!r}")
+    init_kwargs: Dict[str, Any] = {}
+    for fld in fields(cls):
+        json_name = fld.metadata.get("json", fld.name) if fld.metadata else fld.name
+        # Permit lookup by the json key OR the snake_case attribute name.
+        for key in (json_name, fld.name):
+            if key in data:
+                value = data[key]
+                init_kwargs[fld.name] = _decode_field(fld, value)
+                break
+    try:
+        return cls(**init_kwargs)  # type: ignore[call-arg]
+    except TypeError:
+        # Some dataclasses have required positional fields — fall back: instantiate
+        # with available kwargs and silently drop missing ones by using getattr fallback.
+        # Build a "safe" version by providing defaults for missing required fields.
+        instance = cls.__new__(cls)  # type: ignore[call-arg]
+        for fld in fields(cls):
+            setattr(instance, fld.name, init_kwargs.get(fld.name, _default_for_field(fld)))
+        return instance
+
+
+def _decode_field(fld, value: Any) -> Any:
+    # Detect List[X] of dataclass and dict-of-X
+    inner = _list_of_dataclass(fld.type)
+    if inner and isinstance(value, list):
+        return [from_dict(inner, v) if isinstance(v, dict) else v for v in value]
+    nested = _dataclass_type(fld.type)
+    if nested and isinstance(value, dict):
+        return from_dict(nested, value)
+    return value
+
+
+def _dataclass_type(tp: Any):
+    # str type-hints (PEP 563) won't resolve here; we rely on generic dict pass-through.
+    if isinstance(tp, type) and is_dataclass(tp):
+        return tp
+    return None
+
+
+def _list_of_dataclass(tp: Any):
+    # Best-effort: handle typing.List[X]
+    origin = getattr(tp, "__origin__", None)
+    if origin is list:
+        args = getattr(tp, "__args__", ())
+        if args and isinstance(args[0], type) and is_dataclass(args[0]):
+            return args[0]
+    return None
+
+
+def _default_for_field(fld) -> Any:
+    if fld.default is not None and fld.default is not getattr(fld, "_MISSING_TYPE", None):
+        try:
+            from dataclasses import MISSING
+
+            if fld.default is not MISSING:
+                return fld.default
+        except Exception:
+            pass
+    if fld.default_factory is not None:  # type: ignore[attr-defined]
+        try:
+            from dataclasses import MISSING
+
+            if fld.default_factory is not MISSING:  # type: ignore[attr-defined]
+                return fld.default_factory()  # type: ignore[misc]
+        except Exception:
+            pass
+    return None
+
+
+def list_from_items(cls: Type[T], data: Any, key: str = "Items") -> List[T]:
+    if data is None:
+        return []
+    items = data.get(key) if isinstance(data, dict) else None
+    if not isinstance(items, list):
+        return []
+    out: List[T] = []
+    for item in items:
+        decoded = from_dict(cls, item)
+        if decoded is not None:
+            out.append(decoded)
+    return out
+
+
+def drop_empty(d: Dict[str, Any]) -> Dict[str, Any]:
+    return {k: v for k, v in d.items() if v not in (None, "", [], {})}

--- a/libs/hibot/hibot/v1/agents.py
+++ b/libs/hibot/hibot/v1/agents.py
@@ -1,0 +1,162 @@
+"""V1 Agents service."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .._request import Action
+from .._version import SERVER_VERSION
+from ._helpers import from_dict, list_from_items
+from .types import (
+    V1Agent,
+    V1AgentBatchGetParams,
+    V1AgentDeleteParams,
+    V1AgentGetParams,
+    V1AgentListParams,
+    V1AgentNewParams,
+    V1AgentUpdateParams,
+)
+
+
+def _build_resource_input(resources):
+    if not resources:
+        return None
+    resource_ids = []
+    directory_ids = []
+    for r in resources:
+        if r.directory_id:
+            directory_ids.append(r.directory_id)
+        elif r.id:
+            resource_ids.append(r.id)
+    out = {}
+    if resource_ids:
+        out["ResourceIDs"] = resource_ids
+    if directory_ids:
+        out["DirectoryIDs"] = directory_ids
+    return out or None
+
+
+def _build_tool_bindings(tools):
+    skills = []
+    mcps = []
+    if not tools:
+        return skills, mcps
+    for t in tools:
+        if t.of_skill is not None and t.of_skill.skill_version_id:
+            skills.append({"ID": t.of_skill.skill_version_id})
+        if t.of_mcp is not None and t.of_mcp.id:
+            mcps.append({"ID": t.of_mcp.id, "Enabled": True})
+    return skills, mcps
+
+
+class AgentsService:
+    def __init__(self, v1) -> None:
+        self._v1 = v1
+
+    def _action(self, name: str, body):
+        return self._v1.requester.do_action(
+            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+        )
+
+    def create(self, params: Optional[V1AgentNewParams] = None, **kwargs) -> V1Agent:
+        if params is None:
+            params = V1AgentNewParams(**kwargs)
+        env_id = params.env_id
+        if not env_id:
+            env = self._v1.environments.default(workspace_id=params.workspace_id)
+            env_id = env.id
+        body = {
+            "Name": params.name,
+            "ModelID": params.model.id,
+            "EnvID": env_id,
+        }
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.system is not None:
+            body["SystemPrompt"] = params.system
+        resources = _build_resource_input(params.resources)
+        if resources:
+            body["Resources"] = resources
+        skills, mcps = _build_tool_bindings(params.tools)
+        if skills:
+            body["Skills"] = skills
+        if mcps:
+            body["MCPs"] = mcps
+        result = self._action("CreateAgent", body)
+        agent = from_dict(V1Agent, result) or V1Agent()
+        if not agent.id:
+            raise ValueError("hibot: create agent response missing ID")
+        agent.name = agent.name or params.name
+        agent.model_id = agent.model_id or params.model.id
+        return agent
+
+    def list(self, params: V1AgentListParams = V1AgentListParams()) -> List[V1Agent]:
+        body = {}
+        if params.keyword:
+            body["Keyword"] = params.keyword
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("ListAgents", body)
+        return list_from_items(V1Agent, result)
+
+    def get(self, params: V1AgentGetParams) -> V1Agent:
+        if not params.agent_id:
+            raise ValueError("hibot: agent id is required")
+        body = {"AgentID": params.agent_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetAgent", body)
+        agent = from_dict(V1Agent, result) or V1Agent()
+        if not agent.id:
+            raise ValueError("hibot: get agent response missing ID")
+        return agent
+
+    def batch_get(self, params: V1AgentBatchGetParams) -> List[V1Agent]:
+        if not params.agent_ids:
+            raise ValueError("hibot: AgentIDs is required")
+        body = {"AgentIDs": list(params.agent_ids)}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("BatchGetAgents", body)
+        return list_from_items(V1Agent, result)
+
+    def update(self, params: V1AgentUpdateParams) -> None:
+        if not params.agent_id:
+            raise ValueError("hibot: agent id is required")
+        body = {"AgentID": params.agent_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.description is not None:
+            body["Description"] = params.description
+        if params.model_id is not None:
+            body["ModelID"] = params.model_id
+        if params.env_id is not None:
+            body["EnvID"] = params.env_id
+        if params.system is not None:
+            body["SystemPrompt"] = params.system
+        if params.skills is not None:
+            skills_list = []
+            for t in params.skills:
+                if not t.skill_version_id:
+                    continue
+                skills_list.append({"ID": t.skill_version_id})
+            body["Skills"] = skills_list
+        if params.mcps is not None:
+            mcps_list = []
+            for t in params.mcps:
+                if not t.id:
+                    continue
+                mcps_list.append({"ID": t.id, "Enabled": True})
+            body["MCPs"] = mcps_list
+        if params.reset_resources or params.resources:
+            resources = _build_resource_input(params.resources)
+            body["Resources"] = resources or {}
+        self._action("UpdateAgent", body)
+
+    def delete(self, params: V1AgentDeleteParams) -> None:
+        if not params.agent_id:
+            raise ValueError("hibot: agent id is required")
+        body = {"AgentID": params.agent_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("DeleteAgent", body)

--- a/libs/hibot/hibot/v1/base_models.py
+++ b/libs/hibot/hibot/v1/base_models.py
@@ -1,0 +1,120 @@
+"""aigw built-in base models (mirrors go/hibot/v1/base_models.go).
+
+Generated from a real ListModelProvider call against the cluster.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Base model types
+BASE_MODEL_TYPE_TEXT_GENERATION = "text-generation"
+BASE_MODEL_TYPE_EMBEDDINGS = "embeddings"
+BASE_MODEL_TYPE_VISION = "vision"
+BASE_MODEL_TYPE_AUDIO = "audio"
+BASE_MODEL_TYPE_RERANKING = "reranking"
+
+# Base model providers
+BASE_MODEL_PROVIDER_VOLCENGINE = "volcengine"
+BASE_MODEL_PROVIDER_BYTEPLUS = "byteplus"
+BASE_MODEL_PROVIDER_VOLCENGINE_AICC = "volcengine_aicc"
+BASE_MODEL_PROVIDER_ZHIPU = "zhipu"
+BASE_MODEL_PROVIDER_KIMI = "kimi"
+BASE_MODEL_PROVIDER_MINIMAX = "minimax"
+BASE_MODEL_PROVIDER_DEEPSEEK = "deepseek"
+BASE_MODEL_PROVIDER_AWS = "aws"
+BASE_MODEL_PROVIDER_AZURE_OPENAI = "azure_openai"
+BASE_MODEL_PROVIDER_OPENAI = "openai"
+BASE_MODEL_PROVIDER_TONGYI = "tongyi"
+BASE_MODEL_PROVIDER_WENXIN = "wenxin"
+BASE_MODEL_PROVIDER_GOOGLE = "google"
+BASE_MODEL_PROVIDER_ANTHROPIC = "anthropic"
+BASE_MODEL_PROVIDER_LOCALAI = "localai"
+
+
+@dataclass(frozen=True)
+class BaseModel:
+    provider: str
+    type: str
+    model_name: str
+
+
+BASE_MODELS = [
+    BaseModel("azure_openai", "embeddings", "text-embedding-3-large"),
+    BaseModel("azure_openai", "embeddings", "text-embedding-3-small"),
+    BaseModel("azure_openai", "embeddings", "text-embedding-ada-002"),
+    BaseModel("azure_openai", "text-generation", "gpt-4"),
+    BaseModel("azure_openai", "text-generation", "gpt-4o-mini"),
+    BaseModel("azure_openai", "text-generation", "o1"),
+    BaseModel("azure_openai", "text-generation", "o1-preview"),
+    BaseModel("byteplus", "audio", "seed-tts-1.0"),
+    BaseModel("byteplus", "audio", "seed-tts-2.0"),
+    BaseModel("byteplus", "audio", "volc.bigasr.sauc.duration"),
+    BaseModel("byteplus", "audio", "volc.seedasr.sauc.duration"),
+    BaseModel("byteplus", "text-generation", "deepseek-v3"),
+    BaseModel("byteplus", "text-generation", "deepseek-v3-2-251201"),
+    BaseModel("byteplus", "text-generation", "glm-4-7-251222"),
+    BaseModel("byteplus", "text-generation", "kimi-k2-thinking-251104"),
+    BaseModel("byteplus", "text-generation", "seed-1-6-250615"),
+    BaseModel("byteplus", "text-generation", "seed-1-6-flash-250615"),
+    BaseModel("byteplus", "text-generation", "seed-1-8-251228"),
+    BaseModel("byteplus", "text-generation", "seed-2-0-lite-260228"),
+    BaseModel("byteplus", "text-generation", "seed-2-0-mini-260215"),
+    BaseModel("byteplus", "text-generation", "seed-2-0-pro-260328"),
+    BaseModel("byteplus", "vision", "dreamina-seedance-2-0-260128"),
+    BaseModel("byteplus", "vision", "dreamina-seedance-2-0-fast-260128"),
+    BaseModel("byteplus", "vision", "seedream-5.0-lite-260128"),
+    BaseModel("kimi", "text-generation", "kimi-k2.5"),
+    BaseModel("minimax", "text-generation", "minimax-m2.5"),
+    BaseModel("minimax", "text-generation", "minimax-m2.7"),
+    BaseModel("openai", "embeddings", "text-embedding-3-large"),
+    BaseModel("openai", "embeddings", "text-embedding-3-small"),
+    BaseModel("openai", "embeddings", "text-embedding-ada-002"),
+    BaseModel("openai", "text-generation", "gpt-3.5-turbo"),
+    BaseModel("openai", "text-generation", "gpt-4"),
+    BaseModel("openai", "text-generation", "gpt-4o"),
+    BaseModel("openai", "text-generation", "gpt-4o-mini"),
+    BaseModel("openai", "text-generation", "gpt-5"),
+    BaseModel("openai", "text-generation", "gpt-5-chat-latest"),
+    BaseModel("openai", "text-generation", "gpt-5-mini"),
+    BaseModel("openai", "text-generation", "gpt-5-nano"),
+    BaseModel("openai", "text-generation", "o1"),
+    BaseModel("openai", "text-generation", "o1-mini"),
+    BaseModel("openai", "text-generation", "o1-preview"),
+    BaseModel("tongyi", "embeddings", "qwen3-vl-embedding"),
+    BaseModel("tongyi", "embeddings", "text-embedding-v1"),
+    BaseModel("tongyi", "embeddings", "text-embedding-v2"),
+    BaseModel("tongyi", "reranking", "qwen3-rerank"),
+    BaseModel("tongyi", "text-generation", "qwen-plus-latest"),
+    BaseModel("tongyi", "text-generation", "qwen-turbo-latest"),
+    BaseModel("tongyi", "text-generation", "qwen3-0.6b"),
+    BaseModel("tongyi", "text-generation", "qwen3-1.7b"),
+    BaseModel("tongyi", "text-generation", "qwen3-14b"),
+    BaseModel("tongyi", "text-generation", "qwen3-235b-a22b"),
+    BaseModel("tongyi", "text-generation", "qwen3-30b-a3b"),
+    BaseModel("tongyi", "text-generation", "qwen3-32b"),
+    BaseModel("tongyi", "text-generation", "qwen3-4b"),
+    BaseModel("tongyi", "text-generation", "qwen3-8b"),
+    BaseModel("volcengine", "audio", "seed-tts-2.0"),
+    BaseModel("volcengine", "audio", "volc.bigasr.auc_turbo"),
+    BaseModel("volcengine", "audio", "volc.seedasr.sauc.duration"),
+    BaseModel("volcengine", "text-generation", "deepseek-v3-2-251201"),
+    BaseModel("volcengine", "text-generation", "doubao-1-5-lite"),
+    BaseModel("volcengine", "text-generation", "doubao-seed-2-0-code-preview-260215"),
+    BaseModel("volcengine", "text-generation", "doubao-seed-2-0-lite-260215"),
+    BaseModel("volcengine", "text-generation", "doubao-seed-2-0-mini-260215"),
+    BaseModel("volcengine", "text-generation", "doubao-seed-2-0-pro-260215"),
+    BaseModel("volcengine", "text-generation", "glm-4-7-251222"),
+    BaseModel("volcengine", "vision", "doubao-seedance-2-0-260128"),
+    BaseModel("volcengine", "vision", "doubao-seedance-2-0-fast-260128"),
+    BaseModel("volcengine_aicc", "text-generation", "deepseek-v3-2-251201"),
+    BaseModel("volcengine_aicc", "text-generation", "doubao-seed-1-6-250615"),
+    BaseModel("volcengine_aicc", "text-generation", "doubao-seed-2-0-lite-260215"),
+    BaseModel("volcengine_aicc", "text-generation", "doubao-seed-2-0-pro-260215"),
+    BaseModel("volcengine_aicc", "text-generation", "glm-4-7-251222"),
+    BaseModel("zhipu", "text-generation", "glm-3-turbo"),
+    BaseModel("zhipu", "text-generation", "glm-4"),
+    BaseModel("zhipu", "text-generation", "glm-4v"),
+    BaseModel("zhipu", "text-generation", "glm-5"),
+    BaseModel("zhipu", "text-generation", "glm-5.1"),
+]

--- a/libs/hibot/hibot/v1/environments.py
+++ b/libs/hibot/hibot/v1/environments.py
@@ -1,0 +1,113 @@
+"""V1 Environments service."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .._request import Action
+from .._version import SERVER_VERSION
+from ._helpers import from_dict, list_from_items
+from .types import (
+    V1Environment,
+    V1EnvironmentNewParams,
+    V1EnvironmentUpdateParams,
+)
+
+
+class EnvironmentsService:
+    def __init__(self, v1) -> None:
+        self._v1 = v1
+
+    def _action(self, name: str, body):
+        return self._v1.requester.do_action(
+            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+        )
+
+    def create(self, **kwargs) -> V1Environment:
+        params = kwargs.get("params") or V1EnvironmentNewParams(**kwargs)
+        payload = {}
+        if params.image_type:
+            payload["ImageType"] = params.image_type
+        if params.name:
+            payload["Name"] = params.name
+        if params.description:
+            payload["Description"] = params.description
+        if params.env_vars is not None:
+            payload["EnvVars"] = params.env_vars
+        if params.cpu_limit:
+            payload["CpuLimit"] = params.cpu_limit
+        if params.memory_limit:
+            payload["MemoryLimit"] = params.memory_limit
+        if params.pvc_size:
+            payload["PVCSize"] = params.pvc_size
+        if params.data_path:
+            payload["DataPath"] = params.data_path
+        body = {"Payload": payload}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("CreateEnv", body)
+        env = from_dict(V1Environment, result) or V1Environment()
+        if not env.id:
+            raise ValueError("hibot: create environment response missing ID")
+        env.name = env.name or params.name
+        env.image_type = env.image_type or params.image_type
+        return env
+
+    def list(self, *, workspace_id: str = "") -> List[V1Environment]:
+        body = {}
+        if workspace_id:
+            body["WorkspaceID"] = workspace_id
+        result = self._action("ListEnv", body)
+        return list_from_items(V1Environment, result)
+
+    def get(self, *, env_id: str, workspace_id: str = "") -> V1Environment:
+        if not env_id:
+            raise ValueError("hibot: env id is required")
+        body = {"EnvID": env_id}
+        if workspace_id:
+            body["WorkspaceID"] = workspace_id
+        result = self._action("GetEnv", body)
+        env = from_dict(V1Environment, result) or V1Environment()
+        if not env.id:
+            raise ValueError("hibot: get environment response missing ID")
+        return env
+
+    def update(self, params: V1EnvironmentUpdateParams) -> None:
+        if not params.env_id:
+            raise ValueError("hibot: env id is required")
+        payload = {}
+        if params.name is not None:
+            payload["Name"] = params.name
+        if params.description is not None:
+            payload["Description"] = params.description
+        if params.image_type is not None:
+            payload["ImageType"] = params.image_type
+        if params.env_vars is not None:
+            payload["EnvVars"] = params.env_vars
+        if params.cpu_limit is not None:
+            payload["CpuLimit"] = params.cpu_limit
+        if params.memory_limit is not None:
+            payload["MemoryLimit"] = params.memory_limit
+        if params.pvc_size is not None:
+            payload["PVCSize"] = params.pvc_size
+        if params.data_path is not None:
+            payload["DataPath"] = params.data_path
+        body = {"EnvID": params.env_id, "Payload": payload}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("UpdateEnv", body)
+
+    def delete(self, *, env_id: str, workspace_id: str = "") -> None:
+        if not env_id:
+            raise ValueError("hibot: env id is required")
+        body = {"EnvID": env_id}
+        if workspace_id:
+            body["WorkspaceID"] = workspace_id
+        self._action("DeleteEnv", body)
+
+    def default(self, *, workspace_id: str = "") -> V1Environment:
+        items = self.list(workspace_id=workspace_id)
+        if not items:
+            raise ValueError("hibot: no environment found")
+        items.sort(key=lambda e: e.created_at or "")
+        return items[0]

--- a/libs/hibot/hibot/v1/mcps.py
+++ b/libs/hibot/hibot/v1/mcps.py
@@ -1,0 +1,176 @@
+"""V1 MCPs service."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .._request import Action
+from .._version import SERVER_VERSION
+from ._helpers import from_dict, list_from_items
+from .types import (
+    V1MCP,
+    V1MCPDeleteParams,
+    V1MCPGetParams,
+    V1MCPListParams,
+    V1MCPNewParams,
+    V1MCPResolveParams,
+    V1MCPTestConnectionParams,
+    V1MCPTestConnectionResult,
+    V1MCPUpdateParams,
+)
+
+
+class MCPsService:
+    def __init__(self, v1) -> None:
+        self._v1 = v1
+
+    def _action(self, name: str, body):
+        return self._v1.requester.do_action(
+            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+        )
+
+    def create(self, params: V1MCPNewParams) -> V1MCP:
+        body = {
+            "Name": params.name,
+            "Transport": params.transport,
+        }
+        if params.endpoint:
+            body["URL"] = params.endpoint
+        if params.description:
+            body["Description"] = params.description
+        if params.headers is not None:
+            body["Headers"] = params.headers
+        if params.env is not None:
+            body["Env"] = params.env
+        if params.command:
+            body["Command"] = params.command
+        if params.args:
+            body["Args"] = list(params.args)
+        if params.auth_type:
+            body["AuthType"] = params.auth_type
+        if params.credential is not None:
+            body["Credential"] = {"Name": params.credential.name}
+        if params.tool_allowlist is not None:
+            body["ToolAllowlist"] = list(params.tool_allowlist)
+        if params.tool_denylist is not None:
+            body["ToolDenylist"] = list(params.tool_denylist)
+        if params.tool_prefix:
+            body["ToolPrefix"] = params.tool_prefix
+        if params.timeout:
+            body["Timeout"] = params.timeout
+        if params.source:
+            body["Source"] = params.source
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("CreateMCP", body)
+        new_id = result.get("ID") if isinstance(result, dict) else None
+        if not new_id:
+            raise ValueError("hibot: create mcp response missing ID")
+        return V1MCP(id=new_id, name=params.name, transport=params.transport, endpoint=params.endpoint)
+
+    def list(self, params: V1MCPListParams = V1MCPListParams()) -> List[V1MCP]:
+        body = {}
+        if params.keyword:
+            body["Keyword"] = params.keyword
+        if params.status:
+            body["Status"] = params.status
+        if params.source:
+            body["Source"] = params.source
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("ListMCPs", body)
+        return list_from_items(V1MCP, result)
+
+    def get(self, params: V1MCPGetParams) -> V1MCP:
+        if not params.id:
+            raise ValueError("hibot: mcp id is required")
+        body = {"ID": params.id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetMCP", body)
+        decoded = from_dict(V1MCP, result) or V1MCP()
+        if not decoded.id:
+            raise ValueError("hibot: get mcp response missing ID")
+        return decoded
+
+    def update(self, params: V1MCPUpdateParams) -> None:
+        if not params.id:
+            raise ValueError("hibot: mcp id is required")
+        body = {"ID": params.id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.name is not None:
+            body["Name"] = params.name
+        if params.description is not None:
+            body["Description"] = params.description
+        if params.transport is not None:
+            body["Transport"] = params.transport
+        if params.endpoint is not None:
+            body["URL"] = params.endpoint
+        if params.headers is not None:
+            body["Headers"] = params.headers
+        if params.env is not None:
+            body["Env"] = params.env
+        if params.command is not None:
+            body["Command"] = params.command
+        if params.args is not None:
+            body["Args"] = list(params.args)
+        if params.auth_type is not None:
+            body["AuthType"] = params.auth_type
+        if params.tool_allowlist is not None:
+            body["ToolAllowlist"] = list(params.tool_allowlist)
+        if params.tool_denylist is not None:
+            body["ToolDenylist"] = list(params.tool_denylist)
+        if params.tool_prefix is not None:
+            body["ToolPrefix"] = params.tool_prefix
+        if params.timeout is not None:
+            body["Timeout"] = params.timeout
+        if params.status is not None:
+            body["Status"] = params.status
+        if params.source is not None:
+            body["Source"] = params.source
+        self._action("UpdateMCP", body)
+
+    def delete(self, params: V1MCPDeleteParams) -> None:
+        if not params.id:
+            raise ValueError("hibot: mcp id is required")
+        body = {"ID": params.id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("DeleteMCP", body)
+
+    def test_connection(self, params: V1MCPTestConnectionParams) -> V1MCPTestConnectionResult:
+        body = {}
+        if params.transport:
+            body["Transport"] = params.transport
+        if params.endpoint:
+            body["URL"] = params.endpoint
+        if params.headers is not None:
+            body["Headers"] = params.headers
+        if params.env is not None:
+            body["Env"] = params.env
+        if params.command:
+            body["Command"] = params.command
+        if params.args:
+            body["Args"] = list(params.args)
+        if params.auth_type:
+            body["AuthType"] = params.auth_type
+        if params.credential is not None:
+            body["Credential"] = {"Name": params.credential.name}
+        if params.timeout:
+            body["Timeout"] = params.timeout
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("TestMCPConnection", body)
+        return from_dict(V1MCPTestConnectionResult, result) or V1MCPTestConnectionResult()
+
+    def resolve(self, params: V1MCPResolveParams) -> V1MCP:
+        if params.id:
+            return V1MCP(id=params.id, name=params.name)
+        if not params.name:
+            raise ValueError("hibot: mcp id or name is required")
+        items = self.list(V1MCPListParams(keyword=params.name, workspace_id=params.workspace_id))
+        for item in items:
+            if item.name == params.name and item.id:
+                return item
+        raise ValueError(f'hibot: mcp "{params.name}" not found')

--- a/libs/hibot/hibot/v1/models.py
+++ b/libs/hibot/hibot/v1/models.py
@@ -1,0 +1,236 @@
+"""V1 Models service."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .._request import Action
+from .._version import MODEL_VERSION
+from ._helpers import list_from_items
+from .types import (
+    V1Model,
+    V1ModelDeleteParams,
+    V1ModelGetParams,
+    V1ModelList,
+    V1ModelNewParams,
+    V1ModelProvider,
+    V1ModelProviderCredentialSchemaParams,
+    V1ModelProviderGetParams,
+    V1ModelProviderList,
+    V1ModelProviderListParams,
+    V1ModelUpdateParams,
+)
+
+
+class ModelsService:
+    def __init__(self, v1) -> None:
+        self._v1 = v1
+
+    def _action(self, name: str, body):
+        return self._v1.requester.do_action(
+            Action(service=self._v1.services.model, version=MODEL_VERSION, action=name, body=body)
+        )
+
+    def get(self, params: Optional[V1ModelGetParams] = None, **kwargs) -> V1Model:
+        if params is None:
+            params = V1ModelGetParams(**kwargs)
+        ids = list(params.ids or [])
+        if params.id and not ids:
+            ids = [params.id]
+        if not ids:
+            if not (params.name or params.model_name or params.provider or params.type or params.spec):
+                raise ValueError(
+                    "hibot: model id is required (or provide Name/ModelName/Provider/Type/Spec)"
+                )
+            return self._find_by_filter(params)
+        body = {"IDs": ids}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetModel", body)
+        items = list_from_items(V1Model, result)
+        if not items:
+            raise ValueError("hibot: model not found")
+        matched = self._match(items, params)
+        if matched is None:
+            raise ValueError("hibot: model not found matching filter")
+        return matched
+
+    def _find_by_filter(self, params: V1ModelGetParams) -> V1Model:
+        listing = self.list(name=params.name, workspace_id=params.workspace_id)
+        if not listing.items:
+            raise ValueError("hibot: model not found")
+        matched = self._match(listing.items, params)
+        if matched is None:
+            raise ValueError("hibot: model not found matching filter")
+        return matched
+
+    @staticmethod
+    def _match(items: List[V1Model], params: V1ModelGetParams) -> Optional[V1Model]:
+        for m in items:
+            if params.name and m.name != params.name:
+                continue
+            if params.model_name and m.model_name != params.model_name:
+                continue
+            if params.provider and m.provider != params.provider:
+                continue
+            if params.type and m.type != params.type:
+                continue
+            if params.spec and m.spec != params.spec:
+                continue
+            return m
+        if not (params.name or params.model_name or params.provider or params.type or params.spec):
+            return items[0]
+        return None
+
+    def list(self, *, name: str = "", workspace_id: str = "", page=None, sort_by: str = "", sort_order: str = "") -> V1ModelList:
+        body = {}
+        if workspace_id:
+            body["WorkspaceID"] = workspace_id
+        if page is not None:
+            body["Page"] = page if isinstance(page, dict) else {"PageNum": page.page_num, "PageSize": page.page_size}
+        if sort_by:
+            body["SortBy"] = sort_by
+        if sort_order:
+            body["SortOrder"] = sort_order
+        if name:
+            body["Filter"] = {"Name": name}
+        result = self._action("ListModel", body)
+        ml = V1ModelList()
+        if isinstance(result, dict):
+            ml.items = list_from_items(V1Model, result)
+            ml.total = result.get("Total")
+        return ml
+
+    def create(self, params: V1ModelNewParams) -> V1Model:
+        if not params.name:
+            raise ValueError("hibot: model Name is required")
+        if not params.type:
+            raise ValueError("hibot: model Type is required")
+        body = {
+            "Name": params.name,
+            "Type": params.type,
+        }
+        if params.description:
+            body["Description"] = params.description
+        if params.provider:
+            body["Provider"] = params.provider
+        if params.spec:
+            body["Spec"] = params.spec
+        if params.model_name:
+            body["ModelName"] = params.model_name
+        if params.features_config is not None:
+            body["FeaturesConfig"] = params.features_config
+        if params.property is not None:
+            body["Property"] = params.property
+        if params.credential_schema is not None:
+            body["CredentialSchema"] = params.credential_schema
+        if params.credential is not None:
+            body["Credential"] = params.credential
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("CreateModel", body)
+        new_id = result.get("ID") if isinstance(result, dict) else None
+        if not new_id:
+            raise ValueError("hibot: create model response missing ID")
+        return V1Model(
+            id=new_id,
+            name=params.name,
+            type=params.type,
+            provider=params.provider,
+            spec=params.spec,
+            model_name=params.model_name,
+        )
+
+    def update(self, params: V1ModelUpdateParams) -> None:
+        if not params.id:
+            raise ValueError("hibot: model id is required")
+        if not params.type:
+            raise ValueError("hibot: model Type is required")
+        body = {"ID": params.id, "Type": params.type}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.description:
+            body["Description"] = params.description
+        if params.provider:
+            body["Provider"] = params.provider
+        if params.spec:
+            body["Spec"] = params.spec
+        if params.model_name:
+            body["ModelName"] = params.model_name
+        if params.features_config is not None:
+            body["FeaturesConfig"] = params.features_config
+        if params.property is not None:
+            body["Property"] = params.property
+        if params.credential_schema is not None:
+            body["CredentialSchema"] = params.credential_schema
+        if params.credential is not None:
+            body["Credential"] = params.credential
+        self._action("UpdateModel", body)
+
+    def delete(self, params: V1ModelDeleteParams) -> None:
+        if not params.id:
+            raise ValueError("hibot: model id is required")
+        body = {"ID": params.id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("DeleteModel", body)
+
+    def list_providers(self) -> List[str]:
+        result = self._action("ListProvider", {})
+        if isinstance(result, dict):
+            return list(result.get("Providers") or [])
+        return []
+
+    def list_model_providers(self, params: V1ModelProviderListParams) -> V1ModelProviderList:
+        body = {}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.page is not None:
+            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+        if params.sort_by:
+            body["SortBy"] = params.sort_by
+        if params.sort_order:
+            body["SortOrder"] = params.sort_order
+        flt = {}
+        if params.provider:
+            flt["Provider"] = params.provider
+        if params.type:
+            flt["Type"] = params.type
+        if params.model_name:
+            flt["ModelName"] = params.model_name
+        if params.features:
+            flt["Features"] = list(params.features)
+        if flt:
+            body["Filter"] = flt
+        result = self._action("ListModelProvider", body)
+        out = V1ModelProviderList()
+        if isinstance(result, dict):
+            out.items = list_from_items(V1ModelProvider, result, key="Models")
+            out.total = result.get("Total")
+        return out
+
+    def get_model_provider(self, params: V1ModelProviderGetParams) -> List[V1ModelProvider]:
+        if not params.ids:
+            raise ValueError("hibot: provider IDs are required")
+        body = {"IDs": list(params.ids)}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetProvider", body)
+        return list_from_items(V1ModelProvider, result)
+
+    def get_model_provider_credential_schema(self, params: V1ModelProviderCredentialSchemaParams):
+        if not params.provider:
+            raise ValueError("hibot: provider is required")
+        if not params.type:
+            raise ValueError("hibot: model type is required")
+        body = {"Provider": params.provider, "Type": params.type}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.spec:
+            body["Spec"] = params.spec
+        if params.features:
+            body["Features"] = list(params.features)
+        result = self._action("GetModelProviderCredentialSchema", body)
+        if isinstance(result, dict):
+            return result.get("CredentialSchema")
+        return result

--- a/libs/hibot/hibot/v1/prompts.py
+++ b/libs/hibot/hibot/v1/prompts.py
@@ -1,0 +1,67 @@
+"""V1 Prompts service."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .._request import Action
+from .._version import SERVER_VERSION
+from ._helpers import list_from_items
+from .types import (
+    V1Prompt,
+    V1PromptDeleteParams,
+    V1PromptListParams,
+    V1PromptNewParams,
+    V1PromptUpdateParams,
+)
+
+
+class PromptsService:
+    def __init__(self, v1) -> None:
+        self._v1 = v1
+
+    def _action(self, name: str, body):
+        return self._v1.requester.do_action(
+            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+        )
+
+    def create(self, params: V1PromptNewParams) -> V1Prompt:
+        body = {
+            "Payload": {
+                "Name": params.name,
+                "SystemPrompt": params.content,
+            }
+        }
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("CreateAgentPromptTemplate", body)
+        new_id = result.get("ID") if isinstance(result, dict) else None
+        return V1Prompt(id=new_id, name=params.name, content=params.content)
+
+    def list(self, params: V1PromptListParams = V1PromptListParams()) -> List[V1Prompt]:
+        body = {}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("ListAgentPromptTemplates", body)
+        return list_from_items(V1Prompt, result)
+
+    def update(self, params: V1PromptUpdateParams) -> None:
+        if not params.id:
+            raise ValueError("hibot: prompt id is required")
+        payload = {}
+        if params.name is not None:
+            payload["Name"] = params.name
+        if params.content is not None:
+            payload["SystemPrompt"] = params.content
+        body = {"ID": params.id, "Payload": payload}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("UpdateAgentPromptTemplate", body)
+
+    def delete(self, params: V1PromptDeleteParams) -> None:
+        if not params.id:
+            raise ValueError("hibot: prompt id is required")
+        body = {"ID": params.id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("DeleteAgentPromptTemplate", body)

--- a/libs/hibot/hibot/v1/resources.py
+++ b/libs/hibot/hibot/v1/resources.py
@@ -1,0 +1,182 @@
+"""V1 Resources & Directories services."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .._request import Action
+from .._version import SERVER_VERSION
+from ._helpers import from_dict, list_from_items
+from .types import (
+    V1Directory,
+    V1DirectoryDeleteParams,
+    V1DirectoryGetByNameParams,
+    V1DirectoryList,
+    V1DirectoryListParams,
+    V1DirectoryNewParams,
+    V1DirectoryUpdateParams,
+    V1Resource,
+    V1ResourceBatchGetParams,
+    V1ResourceDeleteParams,
+    V1ResourceGetByNameParams,
+    V1ResourceList,
+    V1ResourceListParams,
+    V1ResourceNewParams,
+    V1ResourceUpdateParams,
+)
+
+
+class _BaseService:
+    def __init__(self, v1) -> None:
+        self._v1 = v1
+
+    def _action(self, name: str, body):
+        return self._v1.requester.do_action(
+            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+        )
+
+
+class DirectoriesService(_BaseService):
+    def create(self, params: V1DirectoryNewParams) -> V1Directory:
+        if not params.name:
+            raise ValueError("hibot: directory name is required")
+        body = {"Name": params.name}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("CreateDirectory", body)
+        new_id = result.get("ID") if isinstance(result, dict) else None
+        if not new_id:
+            raise ValueError("hibot: create directory response missing ID")
+        return V1Directory(id=new_id, name=params.name, workspace_id=params.workspace_id)
+
+    def list(self, params: V1DirectoryListParams = V1DirectoryListParams()) -> V1DirectoryList:
+        body = {}
+        if params.name:
+            body["Name"] = params.name
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.page is not None:
+            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+        result = self._action("ListDirectories", body)
+        out = V1DirectoryList()
+        if isinstance(result, dict):
+            out.items = list_from_items(V1Directory, result)
+        return out
+
+    def update(self, params: V1DirectoryUpdateParams) -> None:
+        if not params.directory_id:
+            raise ValueError("hibot: directory id is required")
+        body = {"DirectoryID": params.directory_id}
+        if params.name:
+            body["Name"] = params.name
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("UpdateDirectory", body)
+
+    def delete(self, params: V1DirectoryDeleteParams) -> None:
+        if not params.directory_id:
+            raise ValueError("hibot: directory id is required")
+        body = {"DirectoryID": params.directory_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("DeleteDirectory", body)
+
+    def get_by_name(self, params: V1DirectoryGetByNameParams) -> V1Directory:
+        if not params.name:
+            raise ValueError("hibot: directory name is required")
+        body = {"Name": params.name}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetDirectoryByName", body)
+        d = result.get("Directory") if isinstance(result, dict) else None
+        decoded = from_dict(V1Directory, d) or V1Directory()
+        if not decoded.id:
+            raise ValueError("hibot: get directory by name response missing ID")
+        return decoded
+
+
+class ResourcesService(_BaseService):
+    def __init__(self, v1) -> None:
+        super().__init__(v1)
+        self.directories = DirectoriesService(v1)
+
+    def create(self, params: V1ResourceNewParams) -> V1Resource:
+        if not params.name:
+            raise ValueError("hibot: resource Name is required")
+        if not params.blob_id:
+            raise ValueError("hibot: resource BlobID is required (call uploads.upload_blob first)")
+        body = {"Name": params.name, "BlobID": params.blob_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.directory_id:
+            body["DirectoryID"] = params.directory_id
+        result = self._action("CreateResource", body)
+        new_id = result.get("ID") if isinstance(result, dict) else None
+        if not new_id:
+            raise ValueError("hibot: create resource response missing ID")
+        return V1Resource(
+            id=new_id,
+            name=params.name,
+            type=params.type,
+            directory_id=params.directory_id,
+        )
+
+    def list(self, params: V1ResourceListParams = V1ResourceListParams()) -> V1ResourceList:
+        body = {}
+        if params.directory_id:
+            body["DirectoryID"] = params.directory_id
+        if params.name:
+            body["Name"] = params.name
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.page is not None:
+            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+        result = self._action("ListResources", body)
+        out = V1ResourceList()
+        if isinstance(result, dict):
+            out.items = list_from_items(V1Resource, result)
+        return out
+
+    def update(self, params: V1ResourceUpdateParams) -> None:
+        if not params.resource_id:
+            raise ValueError("hibot: resource id is required")
+        body = {"ResourceID": params.resource_id, "Name": params.name}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.directory_id is not None:
+            body["DirectoryID"] = params.directory_id
+        self._action("UpdateResource", body)
+
+    def delete(self, params: V1ResourceDeleteParams) -> None:
+        if not params.resource_id:
+            raise ValueError("hibot: resource id is required")
+        body = {"ResourceID": params.resource_id}
+        if params.directory_id:
+            body["DirectoryID"] = params.directory_id
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("DeleteResource", body)
+
+    def get_by_name(self, params: V1ResourceGetByNameParams) -> V1Resource:
+        if not params.name:
+            raise ValueError("hibot: resource name is required")
+        body = {"Name": params.name}
+        if params.directory_id:
+            body["DirectoryID"] = params.directory_id
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetResourceByName", body)
+        r = result.get("Resource") if isinstance(result, dict) else None
+        decoded = from_dict(V1Resource, r) or V1Resource()
+        if not decoded.id:
+            raise ValueError("hibot: get resource by name response missing ID")
+        return decoded
+
+    def batch_get(self, params: V1ResourceBatchGetParams) -> List[V1Resource]:
+        if not params.ids:
+            raise ValueError("hibot: resource IDs are required")
+        body = {"IDs": list(params.ids)}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("BatchGetResources", body)
+        return list_from_items(V1Resource, result)

--- a/libs/hibot/hibot/v1/sessions.py
+++ b/libs/hibot/hibot/v1/sessions.py
@@ -1,0 +1,258 @@
+"""V1 Sessions service (mirrors go/hibot/v1/sessions.go + stream.go entry)."""
+
+from __future__ import annotations
+
+import threading
+
+from .._request import Action
+from .._response import APIError
+from .._version import CHAT_VERSION, SERVER_VERSION
+from ._helpers import from_dict
+from .stream import V1SessionChatStream
+from .types import (
+    V1_SESSION_CHAT_EVENT_FAILED,
+    V1Message,
+    V1MessageGetParams,
+    V1MessageInjectParams,
+    V1MessageList,
+    V1MessageListParams,
+    V1Session,
+    V1SessionArchiveParams,
+    V1SessionChatParams,
+    V1SessionDeleteParams,
+    V1SessionGetByKeyParams,
+    V1SessionGetParams,
+    V1SessionList,
+    V1SessionListParams,
+    V1SessionNewParams,
+)
+
+
+class SessionsService:
+    def __init__(self, v1) -> None:
+        self._v1 = v1
+        self._lock = threading.RLock()
+        self._session_agents: dict[str, str] = {}
+
+    def _action(self, name: str, body):
+        return self._v1.requester.do_action(
+            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+        )
+
+    # CRUD --------------------------------------------------------------
+
+    def create(self, params: V1SessionNewParams) -> V1Session:
+        if not params.agent_id:
+            raise ValueError("hibot: agent id is required")
+        body = {"AgentID": params.agent_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        # Peer 仅在显式指定 IM 渠道或按 user 隔离会话时才需要传入；webchat
+        # 主流程下 SDK 注入 webchat / system / agent_id 作为默认值，确保
+        # 服务端 SessionKey 唯一确定。
+        payload = {
+            "Channel": "webchat",
+            "PeerKind": "system",
+            "PeerID": params.agent_id,
+        }
+        if params.peer is not None:
+            if params.peer.channel:
+                payload["Channel"] = params.peer.channel
+            if params.peer.peer_kind:
+                payload["PeerKind"] = params.peer.peer_kind
+            if params.peer.peer_id:
+                payload["PeerID"] = params.peer.peer_id
+        body["Payload"] = payload
+        result = self._action("CreateSession", body)
+        session = from_dict(V1Session, result) or V1Session()
+        if not session.id:
+            raise ValueError("hibot: create session response missing ID")
+        session.agent_id = params.agent_id
+        with self._lock:
+            self._session_agents[session.id] = params.agent_id
+        return session
+
+    def list(self, params: V1SessionListParams = V1SessionListParams()) -> V1SessionList:
+        body = {}
+        if params.agent_id:
+            body["AgentID"] = params.agent_id
+        if params.status:
+            body["Status"] = params.status
+        if params.channel:
+            body["Channel"] = params.channel
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.page is not None:
+            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+        result = self._action("ListSessions", body)
+        out = V1SessionList()
+        if isinstance(result, dict):
+            from ._helpers import list_from_items
+
+            out.items = list_from_items(V1Session, result)
+            page = result.get("Page")
+            if isinstance(page, dict):
+                from .types import V1Page
+
+                out.page = from_dict(V1Page, page)
+        return out
+
+    def get(self, params: V1SessionGetParams) -> V1Session:
+        if not params.session_id:
+            raise ValueError("hibot: session id is required")
+        body = {"SessionID": params.session_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetSession", body)
+        session = from_dict(V1Session, result) or V1Session()
+        if not session.id:
+            raise ValueError("hibot: get session response missing ID")
+        return session
+
+    def get_by_key(self, params: V1SessionGetByKeyParams) -> V1Session:
+        if not params.session_key:
+            raise ValueError("hibot: session key is required")
+        body = {"SessionKey": params.session_key}
+        if params.agent_id:
+            body["AgentID"] = params.agent_id
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetSessionByKey", body)
+        session = from_dict(V1Session, result) or V1Session()
+        if not session.id:
+            raise ValueError("hibot: get session by key response missing ID")
+        return session
+
+    def archive(self, params: V1SessionArchiveParams) -> None:
+        if not params.session_id:
+            raise ValueError("hibot: session id is required")
+        payload = {}
+        if params.summary:
+            payload["Summary"] = params.summary
+        if params.consolidate is not None:
+            payload["Consolidate"] = params.consolidate
+        body = {"SessionID": params.session_id}
+        if payload:
+            body["Payload"] = payload
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("ArchiveSession", body)
+
+    def delete(self, params: V1SessionDeleteParams) -> None:
+        if not params.session_id:
+            raise ValueError("hibot: session id is required")
+        body = {"SessionID": params.session_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("DeleteSession", body)
+
+    # Messages ----------------------------------------------------------
+
+    def list_messages(self, params: V1MessageListParams) -> V1MessageList:
+        if not params.session_id:
+            raise ValueError("hibot: session id is required")
+        body = {"SessionID": params.session_id}
+        if params.visibility:
+            body["Visibility"] = params.visibility
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.page is not None:
+            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+        result = self._action("ListMessages", body)
+        out = V1MessageList()
+        if isinstance(result, dict):
+            from ._helpers import list_from_items
+
+            out.items = list_from_items(V1Message, result)
+            page = result.get("Page")
+            if isinstance(page, dict):
+                from .types import V1Page
+
+                out.page = from_dict(V1Page, page)
+        return out
+
+    def get_message(self, params: V1MessageGetParams) -> V1Message:
+        if not params.session_id or not params.message_id:
+            raise ValueError("hibot: session id and message id are required")
+        body = {"SessionID": params.session_id, "MessageID": params.message_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetMessage", body)
+        msg = from_dict(V1Message, result) or V1Message()
+        if not msg.id:
+            raise ValueError("hibot: get message response missing ID")
+        return msg
+
+    def inject_message(self, params: V1MessageInjectParams) -> V1Message:
+        if not params.session_id:
+            raise ValueError("hibot: session id is required")
+        payload = {}
+        if params.role:
+            payload["Role"] = params.role
+        if params.content:
+            payload["Content"] = params.content
+        body = {"SessionID": params.session_id, "Payload": payload}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("InjectMessage", body)
+        msg = from_dict(V1Message, result) or V1Message()
+        if not msg.id:
+            raise ValueError("hibot: inject message response missing ID")
+        return msg
+
+    # Chat --------------------------------------------------------------
+
+    def chat(self, session_id: str, params: V1SessionChatParams) -> V1Message:
+        with self.chat_streaming(session_id, params) as stream:
+            for event in stream:
+                if event.type == V1_SESSION_CHAT_EVENT_FAILED:
+                    msg = event.error.message or event.error.code or "unknown error"
+                    raise APIError(status_code=0, message=f"hibot: chat failed: {msg}")
+            if stream.err is not None:
+                raise stream.err
+            return stream.final_message()
+
+    def chat_streaming(self, session_id: str, params: V1SessionChatParams) -> V1SessionChatStream:
+        if not session_id:
+            return V1SessionChatStream(error=ValueError("hibot: session id is required"))
+        agent_id = params.agent_id
+        if not agent_id:
+            agent_id = self._agent_id_for_session(session_id)
+        body = {
+            "SessionID": session_id,
+            "AgentID": agent_id,
+            "Content": params.input,
+        }
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.client_message_id:
+            body["ClientMessageID"] = params.client_message_id
+        try:
+            resp = self._v1.requester.stream_action(
+                Action(
+                    service=self._v1.services.gateway,
+                    version=CHAT_VERSION,
+                    action="Chat",
+                    body=body,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            return V1SessionChatStream(error=exc)
+        if resp.status_code >= 400:
+            try:
+                body_bytes = resp.read_all()
+            finally:
+                resp.close()
+            return V1SessionChatStream(
+                error=APIError(status_code=resp.status_code, message=body_bytes.decode("utf-8", "replace"))
+            )
+        return V1SessionChatStream(resp=resp)
+
+    # internal ----------------------------------------------------------
+
+    def _agent_id_for_session(self, session_id: str) -> str:
+        with self._lock:
+            return self._session_agents.get(session_id, "")
+
+
+__all__ = ["SessionsService"]

--- a/libs/hibot/hibot/v1/skills.py
+++ b/libs/hibot/hibot/v1/skills.py
@@ -1,0 +1,178 @@
+"""V1 Skills service."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .._request import Action
+from .._version import SERVER_VERSION
+from ._helpers import from_dict, list_from_items
+from .types import (
+    V1Skill,
+    V1SkillDeleteParams,
+    V1SkillGetParams,
+    V1SkillListParams,
+    V1SkillNewParams,
+    V1SkillResolveVersionParams,
+    V1SkillUpdateParams,
+    V1SkillVersion,
+    V1SkillVersionListParams,
+)
+
+
+class SkillsService:
+    def __init__(self, v1) -> None:
+        self._v1 = v1
+
+    def _action(self, name: str, body):
+        return self._v1.requester.do_action(
+            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+        )
+
+    def create(self, params: V1SkillNewParams) -> V1SkillVersion:
+        body = {
+            "Name": params.name,
+            "Description": params.description,
+            "Source": params.source or "manual",
+            "Version": params.version,
+        }
+        if params.skill_id:
+            body["SkillID"] = params.skill_id
+        if params.blob_id:
+            body["BlobID"] = params.blob_id
+        if params.enabled is not None:
+            body["Enabled"] = params.enabled
+        if params.slug_id:
+            body["SlugID"] = params.slug_id
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("CreateSkill", body)
+        new_id = result.get("ID") if isinstance(result, dict) else None
+        if not new_id:
+            raise ValueError("hibot: create skill response missing ID")
+        return V1SkillVersion(
+            id=new_id,
+            skill_id=params.skill_id,
+            name=params.name,
+            version=params.version,
+        )
+
+    def list(self, params: V1SkillListParams = V1SkillListParams()) -> List[V1Skill]:
+        body = {}
+        if params.keyword:
+            body["Keyword"] = params.keyword
+        if params.source:
+            body["Source"] = params.source
+        if params.name:
+            body["Name"] = params.name
+        if params.slug_id:
+            body["SlugID"] = params.slug_id
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("ListSkills", body)
+        return list_from_items(V1Skill, result)
+
+    def get(self, params: V1SkillGetParams) -> V1Skill:
+        if not params.id and not params.skill_id:
+            raise ValueError("hibot: skill id or skill_id is required")
+        body = {}
+        if params.id:
+            body["ID"] = params.id
+        if params.skill_id:
+            body["SkillID"] = params.skill_id
+        if params.version:
+            body["Version"] = params.version
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetSkill", body)
+        decoded = from_dict(V1Skill, result) or V1Skill()
+        if not decoded.id:
+            raise ValueError("hibot: get skill response missing ID")
+        return decoded
+
+    def update(self, params: V1SkillUpdateParams) -> None:
+        if not params.id and not params.skill_id:
+            raise ValueError("hibot: skill id or skill_id is required")
+        body = {}
+        if params.id:
+            body["ID"] = params.id
+        if params.skill_id:
+            body["SkillID"] = params.skill_id
+        if params.version:
+            body["Version"] = params.version
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.description is not None:
+            body["Description"] = params.description
+        if params.source is not None:
+            body["Source"] = params.source
+        if params.artifact_id is not None:
+            body["ArtifactID"] = params.artifact_id
+        if params.enabled is not None:
+            body["Enabled"] = params.enabled
+        if params.new_version is not None:
+            body["NewVersion"] = params.new_version
+        if params.slug_id is not None:
+            body["SlugID"] = params.slug_id
+        self._action("UpdateSkill", body)
+
+    def delete(self, params: V1SkillDeleteParams) -> None:
+        if not params.id and not params.skill_id:
+            raise ValueError("hibot: skill id or skill_id is required")
+        body = {}
+        if params.id:
+            body["ID"] = params.id
+        if params.skill_id:
+            body["SkillID"] = params.skill_id
+        if params.version:
+            body["Version"] = params.version
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("DeleteSkill", body)
+
+    def list_versions(self, params: V1SkillVersionListParams) -> List[V1SkillVersion]:
+        if not params.skill_id:
+            raise ValueError("hibot: skill_id is required")
+        body = {"SkillID": params.skill_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.sort_by:
+            body["SortBy"] = params.sort_by
+        if params.sort_order:
+            body["SortOrder"] = params.sort_order
+        if params.page is not None:
+            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+        result = self._action("ListSkillVersions", body)
+        return list_from_items(V1SkillVersion, result)
+
+    def resolve_version(self, params: V1SkillResolveVersionParams) -> V1SkillVersion:
+        if params.id:
+            return V1SkillVersion(id=params.id, name=params.name, constraint=params.constraint)
+        skill_id = self._resolve_skill_id(params)
+        body = {"SkillID": skill_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("ListSkillVersions", body)
+        items = list_from_items(V1SkillVersion, result)
+        if not items or not items[0].id:
+            raise ValueError(
+                f'hibot: no skill version matched name="{params.name}" constraint="{params.constraint}"'
+            )
+        v = items[0]
+        v.name = params.name
+        v.constraint = params.constraint
+        return v
+
+    def _resolve_skill_id(self, params: V1SkillResolveVersionParams) -> str:
+        body = {"Name": params.name}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("ListSkills", body)
+        if isinstance(result, dict):
+            for item in result.get("Items") or []:
+                if item.get("Name") == params.name and item.get("SkillID"):
+                    return item["SkillID"]
+            for item in result.get("Items") or []:
+                if item.get("SkillID"):
+                    return item["SkillID"]
+        raise ValueError(f'hibot: skill "{params.name}" not found')

--- a/libs/hibot/hibot/v1/stream.py
+++ b/libs/hibot/hibot/v1/stream.py
@@ -1,0 +1,266 @@
+"""V1 chat stream (mirrors go/hibot/v1/stream.go)."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterator, List, Optional
+
+from .._response import APIError
+from .._sse import ByteStreamDecoder, Frame
+from ._helpers import from_dict
+from .types import (
+    V1_SESSION_CHAT_EVENT_COMPLETED,
+    V1_SESSION_CHAT_EVENT_DELTA,
+    V1_SESSION_CHAT_EVENT_FAILED,
+    V1_SESSION_CHAT_EVENT_TOOL_COMPLETE,
+    V1_SESSION_CHAT_EVENT_TOOL_START,
+    V1Message,
+    V1SessionChatError,
+    V1SessionChatEvent,
+    V1SessionTextDelta,
+)
+
+# Compat event names emitted by gateway legacy delivery + private Hermes runtime.
+_MESSAGE_CHUNK_COMPAT = "message.chunk"
+_MESSAGE_COMPLETED_COMPAT = "message.completed"
+_MESSAGE_FAILED_COMPAT = "message.failed"
+_MESSAGE_DELTA_UNDERSCORE = "message_delta"
+_MESSAGE_CHUNK_UNDERSCORE = "message_chunk"
+_MESSAGE_COMPLETED_UNDERSCORE = "message_completed"
+_MESSAGE_FAILED_UNDERSCORE = "message_failed"
+_RUN_COMPLETED_UNDERSCORE = "run_completed"
+_RUN_FAILED_UNDERSCORE = "run_failed"
+
+
+def normalize_chat_event_name(name: str) -> str:
+    if name in (
+        _MESSAGE_CHUNK_COMPAT,
+        _MESSAGE_DELTA_UNDERSCORE,
+        _MESSAGE_CHUNK_UNDERSCORE,
+    ):
+        return V1_SESSION_CHAT_EVENT_DELTA
+    if name in (
+        _MESSAGE_COMPLETED_COMPAT,
+        _MESSAGE_COMPLETED_UNDERSCORE,
+        _RUN_COMPLETED_UNDERSCORE,
+    ):
+        return V1_SESSION_CHAT_EVENT_COMPLETED
+    if name in (
+        _MESSAGE_FAILED_COMPAT,
+        _MESSAGE_FAILED_UNDERSCORE,
+        _RUN_FAILED_UNDERSCORE,
+    ):
+        return V1_SESSION_CHAT_EVENT_FAILED
+    if name == "tool_started":
+        return V1_SESSION_CHAT_EVENT_TOOL_START
+    if name == "tool_completed":
+        return V1_SESSION_CHAT_EVENT_TOOL_COMPLETE
+    return name
+
+
+def _first_key(payload: dict, *keys: str):
+    for k in keys:
+        if k in payload:
+            return payload[k]
+    return None
+
+
+def decode_chat_event(event_name: str, data: str) -> V1SessionChatEvent:
+    event = V1SessionChatEvent(type=normalize_chat_event_name(event_name), raw_data=data or "")
+    if not data:
+        return event
+    try:
+        payload = json.loads(data)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"hibot: decode sse data: {exc}") from exc
+    if not isinstance(payload, dict):
+        return event
+
+    if not event.type:
+        raw_type = payload.get("type")
+        if isinstance(raw_type, str):
+            event.type = normalize_chat_event_name(raw_type)
+
+    rid = _first_key(payload, "request_id", "RequestID", "RequestId")
+    if isinstance(rid, str):
+        event.request_id = rid
+
+    delta_raw = payload.get("delta")
+    if isinstance(delta_raw, dict):
+        text = delta_raw.get("text") or delta_raw.get("Text")
+        if isinstance(text, str):
+            event.delta = V1SessionTextDelta(text=text)
+    elif isinstance(delta_raw, str):
+        event.delta = V1SessionTextDelta(text=delta_raw)
+
+    if not event.delta.text:
+        text = _first_key(payload, "text", "Text")
+        if isinstance(text, str):
+            event.delta = V1SessionTextDelta(text=text)
+
+    err = _first_key(payload, "error", "Error")
+    if isinstance(err, dict):
+        code = err.get("code") or err.get("Code") or ""
+        message = err.get("message") or err.get("Message") or ""
+        event.error = V1SessionChatError(code=str(code or ""), message=str(message or ""))
+    elif isinstance(err, str):
+        event.error = V1SessionChatError(message=err)
+
+    code = _first_key(payload, "code", "Code")
+    if not event.error.code and isinstance(code, str):
+        event.error.code = code
+
+    message_raw = _first_key(payload, "message", "Message")
+    if isinstance(message_raw, dict):
+        msg = from_dict(V1Message, message_raw)
+        if msg is not None and (msg.id or msg.content or msg.role):
+            event.message = msg
+    elif isinstance(message_raw, str) and not event.error.message:
+        event.error.message = message_raw
+
+    if event.type == V1_SESSION_CHAT_EVENT_COMPLETED and event.message is None:
+        msg = V1Message()
+        mid = _first_key(payload, "message_id", "MessageID", "ID")
+        if isinstance(mid, str):
+            msg.id = mid
+        content = _first_key(payload, "content", "Content")
+        if isinstance(content, str):
+            msg.content = content
+        if msg.id or msg.content:
+            event.message = msg
+
+    return event
+
+
+class V1SessionChatStream:
+    """Synchronous SSE stream for chat events.
+
+    Supports iterator protocol (``for event in stream``) and context-manager
+    protocol (``with stream as s: ...``). Use ``final_message()`` after the
+    stream completes, or ``accumulate()`` to drain into a single message.
+    """
+
+    def __init__(self, resp=None, *, error: Optional[BaseException] = None) -> None:
+        self._resp = resp
+        self._decoder = ByteStreamDecoder()
+        self._iter: Optional[Iterator[bytes]] = None
+        self._pending: List[Frame] = []
+        self._eof = False
+        self._closed = False
+        self._current: Optional[V1SessionChatEvent] = None
+        self._final: Optional[V1Message] = None
+        self._error: Optional[BaseException] = error
+        if resp is not None and not error:
+            self._iter = iter(resp.iter_bytes())
+
+    # iterator protocol -------------------------------------------------
+    def __iter__(self) -> "V1SessionChatStream":
+        return self
+
+    def __next__(self) -> V1SessionChatEvent:
+        if self.next():
+            return self._current  # type: ignore[return-value]
+        raise StopIteration
+
+    # context manager protocol -----------------------------------------
+    def __enter__(self) -> "V1SessionChatStream":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    # public API --------------------------------------------------------
+    @property
+    def current(self) -> Optional[V1SessionChatEvent]:
+        return self._current
+
+    @property
+    def err(self) -> Optional[BaseException]:
+        return self._error
+
+    def next(self) -> bool:
+        if self._error is not None:
+            return False
+        while True:
+            if self._pending:
+                frame = self._pending.pop(0)
+                try:
+                    event = decode_chat_event(frame.event, frame.data)
+                except Exception as exc:  # noqa: BLE001
+                    self._error = exc
+                    return False
+                self._current = event
+                if event.message is not None:
+                    self._final = event.message
+                return True
+            if self._eof:
+                return False
+            if self._iter is None:
+                self._eof = True
+                return False
+            try:
+                chunk = next(self._iter)
+            except StopIteration:
+                self._eof = True
+                self._decoder.close()
+                self._pending.extend(self._decoder.pop_frames())
+                continue
+            except Exception as exc:  # noqa: BLE001
+                self._error = exc
+                return False
+            self._decoder.feed(chunk or b"")
+            self._pending.extend(self._decoder.pop_frames())
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._resp is not None:
+            try:
+                self._resp.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def final_message(self) -> V1Message:
+        if self._error is not None:
+            raise self._error
+        if self._final is not None:
+            return self._final
+        if self._current is not None and self._current.message is not None:
+            return self._current.message
+        raise ValueError("hibot: final message is not available")
+
+    def accumulate(self) -> V1Message:
+        buf: List[str] = []
+        final_msg: Optional[V1Message] = None
+        while self.next():
+            event = self._current
+            if event is None:
+                continue
+            if event.type == V1_SESSION_CHAT_EVENT_FAILED:
+                msg = event.error.message or event.error.code or "unknown error"
+                raise APIError(status_code=0, message=f"hibot: chat failed: {msg}")
+            if event.type == V1_SESSION_CHAT_EVENT_DELTA:
+                if event.delta.text:
+                    buf.append(event.delta.text)
+            elif event.type == V1_SESSION_CHAT_EVENT_COMPLETED:
+                if event.message is not None:
+                    final_msg = event.message
+        if self._error is not None:
+            raise self._error
+        if final_msg is None:
+            final_msg = self._final
+        if final_msg is None:
+            if not buf:
+                raise ValueError("hibot: final message is not available")
+            return V1Message(role="assistant", content="".join(buf))
+        if not final_msg.content and buf:
+            final_msg.content = "".join(buf)
+        return final_msg
+
+
+__all__ = [
+    "V1SessionChatStream",
+    "decode_chat_event",
+    "normalize_chat_event_name",
+]

--- a/libs/hibot/hibot/v1/types.py
+++ b/libs/hibot/hibot/v1/types.py
@@ -1,0 +1,890 @@
+"""Data classes for V1 API resources.
+
+All result classes are decoded from server responses with PascalCase JSON
+field names (mirroring the Go SDK structs). Parameter classes use Python
+``snake_case`` attributes; the corresponding service is responsible for
+building the wire-format request dict.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# ---------------- Constants (sync with go/hibot/v1/types.go) ----------------
+
+V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO = "doubao-seed-2.0-pro-260215"
+V1_RESOURCE_TYPE_DOCUMENT_COLLECTION = "document_collection"
+V1_MCP_TRANSPORT_STREAMABLE_HTTP = "streamable_http"
+
+V1_MANAGED_AGENT_SKILL_TOOL_PARAMS_TYPE_SKILL = "skill"
+V1_MANAGED_AGENT_MCP_TOOL_PARAMS_TYPE_MCP = "mcp"
+
+V1_SESSION_CHAT_EVENT_DELTA = "delta"
+V1_SESSION_CHAT_EVENT_COMPLETED = "completed"
+V1_SESSION_CHAT_EVENT_FAILED = "failed"
+V1_SESSION_CHAT_EVENT_RUN_CANCELLING = "run_cancelling"
+V1_SESSION_CHAT_EVENT_RUN_CANCELLED = "run_cancelled"
+V1_SESSION_CHAT_EVENT_APPROVAL_REQUEST = "approval_request"
+V1_SESSION_CHAT_EVENT_APPROVAL_RESPONDED = "approval_responded"
+V1_SESSION_CHAT_EVENT_TOOL_START = "tool_start"
+V1_SESSION_CHAT_EVENT_TOOL_COMPLETE = "tool_complete"
+
+
+# ---------------- Helpers ----------------
+
+def _from_dict(cls, data):
+    """Construct a dataclass instance from a server-side dict, ignoring extras."""
+    if data is None:
+        return None
+    if isinstance(data, cls):
+        return data
+    if not isinstance(data, dict):
+        return None
+    fields_map = {f.name: f for f in cls.__dataclass_fields__.values()}  # type: ignore[attr-defined]
+    kwargs: Dict[str, Any] = {}
+    for name, fld in fields_map.items():
+        # support PascalCase keys
+        for key in (fld.metadata.get("json"), name):
+            if key and key in data:
+                kwargs[name] = data[key]
+                break
+    return cls(**kwargs)
+
+
+def _f(json_name: str):
+    return field(default=None, metadata={"json": json_name})
+
+
+# ---------------- Result types ----------------
+
+@dataclass
+class V1Page:
+    page_num: Optional[int] = field(default=None, metadata={"json": "PageNum"})
+    page_size: Optional[int] = field(default=None, metadata={"json": "PageSize"})
+    total: Optional[int] = field(default=None, metadata={"json": "Total"})
+
+
+@dataclass
+class V1UploadBlob:
+    blob_id: Optional[str] = field(default=None, metadata={"json": "BlobID"})
+
+
+@dataclass
+class V1Environment:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    image_type: Optional[str] = field(default=None, metadata={"json": "ImageType"})
+    env_vars: Optional[Any] = field(default=None, metadata={"json": "EnvVars"})
+    cpu_limit: Optional[str] = field(default=None, metadata={"json": "CpuLimit"})
+    memory_limit: Optional[str] = field(default=None, metadata={"json": "MemoryLimit"})
+    pvc_size: Optional[str] = field(default=None, metadata={"json": "PVCSize"})
+    data_path: Optional[str] = field(default=None, metadata={"json": "DataPath"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+    created_by: Optional[str] = field(default=None, metadata={"json": "CreatedBy"})
+    updated_by: Optional[str] = field(default=None, metadata={"json": "UpdatedBy"})
+
+
+@dataclass
+class V1Model:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    type: Optional[str] = field(default=None, metadata={"json": "Type"})
+    provider: Optional[str] = field(default=None, metadata={"json": "Provider"})
+    spec: Optional[str] = field(default=None, metadata={"json": "Spec"})
+    model_name: Optional[str] = field(default=None, metadata={"json": "ModelName"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+    features_config: Optional[Any] = field(default=None, metadata={"json": "FeaturesConfig"})
+    property: Optional[Any] = field(default=None, metadata={"json": "Property"})
+    credential_schema: Optional[Any] = field(default=None, metadata={"json": "CredentialSchema"})
+    credential: Optional[Dict[str, str]] = field(default=None, metadata={"json": "Credential"})
+    create_time: Optional[str] = field(default=None, metadata={"json": "CreateTime"})
+    update_time: Optional[str] = field(default=None, metadata={"json": "UpdateTime"})
+
+
+@dataclass
+class V1ModelList:
+    items: List[V1Model] = field(default_factory=list, metadata={"json": "Items"})
+    total: Optional[int] = field(default=None, metadata={"json": "Total"})
+
+
+@dataclass
+class V1ModelProvider:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    type: Optional[str] = field(default=None, metadata={"json": "Type"})
+    provider: Optional[str] = field(default=None, metadata={"json": "Provider"})
+    model_name: Optional[str] = field(default=None, metadata={"json": "ModelName"})
+    features_config: Optional[Any] = field(default=None, metadata={"json": "FeaturesConfig"})
+    property: Optional[Any] = field(default=None, metadata={"json": "Property"})
+    credential_schema: Optional[Any] = field(default=None, metadata={"json": "CredentialSchema"})
+
+
+@dataclass
+class V1ModelProviderList:
+    items: List[V1ModelProvider] = field(default_factory=list, metadata={"json": "Models"})
+    total: Optional[int] = field(default=None, metadata={"json": "Total"})
+
+
+@dataclass
+class V1Prompt:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    content: Optional[str] = field(default=None, metadata={"json": "SystemPrompt"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+
+
+@dataclass
+class V1Resource:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    type: Optional[str] = field(default=None, metadata={"json": "Type"})
+    artifact_id: Optional[str] = field(default=None, metadata={"json": "ArtifactID"})
+    size: Optional[int] = field(default=None, metadata={"json": "Size"})
+    extension: Optional[str] = field(default=None, metadata={"json": "Extension"})
+    workspace_id: Optional[str] = field(default=None, metadata={"json": "WorkspaceID"})
+    directory_id: Optional[str] = field(default=None, metadata={"json": "DirectoryID"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+
+
+@dataclass
+class V1ResourceList:
+    items: List[V1Resource] = field(default_factory=list, metadata={"json": "Items"})
+    page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
+
+
+@dataclass
+class V1Directory:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    workspace_id: Optional[str] = field(default=None, metadata={"json": "WorkspaceID"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    resource_count: Optional[int] = field(default=None, metadata={"json": "ResourceCount"})
+
+
+@dataclass
+class V1DirectoryList:
+    items: List[V1Directory] = field(default_factory=list, metadata={"json": "Items"})
+    page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
+
+
+@dataclass
+class V1MCP:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    transport: Optional[str] = field(default=None, metadata={"json": "Transport"})
+    endpoint: Optional[str] = field(default=None, metadata={"json": "URL"})
+    headers: Optional[Dict[str, str]] = field(default=None, metadata={"json": "Headers"})
+    env: Optional[Dict[str, str]] = field(default=None, metadata={"json": "Env"})
+    command: Optional[str] = field(default=None, metadata={"json": "Command"})
+    args: Optional[List[str]] = field(default=None, metadata={"json": "Args"})
+    auth_type: Optional[str] = field(default=None, metadata={"json": "AuthType"})
+    tool_allowlist: Optional[List[str]] = field(default=None, metadata={"json": "ToolAllowlist"})
+    tool_denylist: Optional[List[str]] = field(default=None, metadata={"json": "ToolDenylist"})
+    tool_prefix: Optional[str] = field(default=None, metadata={"json": "ToolPrefix"})
+    timeout: Optional[int] = field(default=None, metadata={"json": "Timeout"})
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+    source: Optional[str] = field(default=None, metadata={"json": "Source"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+
+
+@dataclass
+class V1MCPTool:
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+
+
+@dataclass
+class V1MCPTestConnectionResult:
+    success: bool = field(default=False, metadata={"json": "Success"})
+    error: Optional[str] = field(default=None, metadata={"json": "Error"})
+    tool_count: int = field(default=0, metadata={"json": "ToolCount"})
+    tools: List[V1MCPTool] = field(default_factory=list, metadata={"json": "Tools"})
+
+
+@dataclass
+class V1Skill:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    skill_id: Optional[str] = field(default=None, metadata={"json": "SkillID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    source: Optional[str] = field(default=None, metadata={"json": "Source"})
+    version: Optional[str] = field(default=None, metadata={"json": "Version"})
+    artifact_id: Optional[str] = field(default=None, metadata={"json": "ArtifactID"})
+    enabled: Optional[bool] = field(default=None, metadata={"json": "Enabled"})
+    slug_id: Optional[str] = field(default=None, metadata={"json": "SlugID"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+
+
+@dataclass
+class V1SkillVersion:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    skill_id: Optional[str] = field(default=None, metadata={"json": "SkillID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    version: Optional[str] = field(default=None, metadata={"json": "Version"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    source: Optional[str] = field(default=None, metadata={"json": "Source"})
+    artifact_id: Optional[str] = field(default=None, metadata={"json": "ArtifactID"})
+    enabled: Optional[bool] = field(default=None, metadata={"json": "Enabled"})
+    slug_id: Optional[str] = field(default=None, metadata={"json": "SlugID"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    constraint: Optional[str] = None  # client-side only
+
+
+@dataclass
+class V1AgentSkillBinding:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    enabled: Optional[bool] = field(default=None, metadata={"json": "Enabled"})
+
+
+@dataclass
+class V1AgentMCPBinding:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    enabled: Optional[bool] = field(default=None, metadata={"json": "Enabled"})
+    tool_allowlist: Optional[List[str]] = field(default=None, metadata={"json": "ToolAllowlist"})
+    tool_denylist: Optional[List[str]] = field(default=None, metadata={"json": "ToolDenylist"})
+
+
+@dataclass
+class V1Agent:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    workspace_id: Optional[str] = field(default=None, metadata={"json": "WorkspaceID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    model_id: Optional[str] = field(default=None, metadata={"json": "ModelID"})
+    env_id: Optional[str] = field(default=None, metadata={"json": "EnvID"})
+    system_prompt: Optional[str] = field(default=None, metadata={"json": "SystemPrompt"})
+    skills: Optional[List[V1AgentSkillBinding]] = field(default=None, metadata={"json": "Skills"})
+    mcps: Optional[List[V1AgentMCPBinding]] = field(default=None, metadata={"json": "MCPs"})
+    resource_ids: Optional[List[str]] = field(default=None, metadata={"json": "ResourceIDs"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+
+
+@dataclass
+class V1Session:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    agent_id: Optional[str] = field(default=None, metadata={"json": "AgentID"})
+    session_key: Optional[str] = field(default=None, metadata={"json": "SessionKey"})
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+    channel: Optional[str] = field(default=None, metadata={"json": "Channel"})
+    peer_kind: Optional[str] = field(default=None, metadata={"json": "PeerKind"})
+    peer_id: Optional[str] = field(default=None, metadata={"json": "PeerID"})
+    risk_level: Optional[str] = field(default=None, metadata={"json": "RiskLevel"})
+    message_count: Optional[int] = field(default=None, metadata={"json": "MessageCount"})
+    last_message_at: Optional[str] = field(default=None, metadata={"json": "LastMessageAt"})
+    last_message_content: Optional[str] = field(default=None, metadata={"json": "LastMessageContent"})
+    summary: Optional[str] = field(default=None, metadata={"json": "Summary"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+    archived_at: Optional[str] = field(default=None, metadata={"json": "ArchivedAt"})
+
+
+@dataclass
+class V1MessageFile:
+    file_id: Optional[str] = field(default=None, metadata={"json": "FileID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    content_type: Optional[str] = field(default=None, metadata={"json": "ContentType"})
+    url: Optional[str] = field(default=None, metadata={"json": "URL"})
+
+
+@dataclass
+class V1Message:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    session_id: Optional[str] = field(default=None, metadata={"json": "SessionID"})
+    run_id: Optional[str] = field(default=None, metadata={"json": "RunID"})
+    role: Optional[str] = field(default=None, metadata={"json": "Role"})
+    content: Optional[str] = field(default=None, metadata={"json": "Content"})
+    visibility: Optional[str] = field(default=None, metadata={"json": "Visibility"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    files: Optional[List[V1MessageFile]] = field(default=None, metadata={"json": "Files"})
+
+
+@dataclass
+class V1MessageList:
+    items: List[V1Message] = field(default_factory=list, metadata={"json": "Items"})
+    page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
+
+
+@dataclass
+class V1SessionList:
+    items: List[V1Session] = field(default_factory=list, metadata={"json": "Items"})
+    page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
+
+
+# ---------------- Param types (snake_case input) ----------------
+
+@dataclass
+class V1UploadBlobParams:
+    filename: str
+    content_type: str = "application/octet-stream"
+
+
+@dataclass
+class V1EnvironmentNewParams:
+    name: str = ""
+    description: str = ""
+    image_type: str = ""
+    env_vars: Optional[Any] = None
+    cpu_limit: str = ""
+    memory_limit: str = ""
+    pvc_size: str = ""
+    data_path: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1EnvironmentUpdateParams:
+    env_id: str
+    workspace_id: str = ""
+    name: Optional[str] = None
+    description: Optional[str] = None
+    image_type: Optional[str] = None
+    env_vars: Optional[Any] = None
+    cpu_limit: Optional[str] = None
+    memory_limit: Optional[str] = None
+    pvc_size: Optional[str] = None
+    data_path: Optional[str] = None
+
+
+@dataclass
+class V1PageInput:
+    page_num: Optional[int] = None
+    page_size: Optional[int] = None
+
+
+@dataclass
+class V1ModelGetParams:
+    id: str = ""
+    ids: Optional[List[str]] = None
+    name: str = ""
+    model_name: str = ""
+    provider: str = ""
+    type: str = ""
+    spec: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ModelListParams:
+    name: str = ""
+    workspace_id: str = ""
+    page: Optional[V1PageInput] = None
+    sort_by: str = ""
+    sort_order: str = ""
+
+
+@dataclass
+class V1ModelNewParams:
+    name: str
+    type: str
+    provider: str = ""
+    spec: str = ""
+    model_name: str = ""
+    description: str = ""
+    features_config: Optional[Any] = None
+    property: Optional[Any] = None
+    credential_schema: Optional[Any] = None
+    credential: Optional[Dict[str, str]] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ModelUpdateParams:
+    id: str
+    type: str
+    description: str = ""
+    provider: str = ""
+    spec: str = ""
+    model_name: str = ""
+    features_config: Optional[Any] = None
+    property: Optional[Any] = None
+    credential_schema: Optional[Any] = None
+    credential: Optional[Dict[str, str]] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ModelDeleteParams:
+    id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ModelProviderListParams:
+    provider: str = ""
+    type: str = ""
+    model_name: str = ""
+    features: Optional[List[str]] = None
+    workspace_id: str = ""
+    page: Optional[V1PageInput] = None
+    sort_by: str = ""
+    sort_order: str = ""
+
+
+@dataclass
+class V1ModelProviderGetParams:
+    ids: List[str]
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ModelProviderCredentialSchemaParams:
+    provider: str
+    type: str
+    spec: str = ""
+    features: Optional[List[str]] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1PromptNewParams:
+    name: str = ""
+    content: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1PromptListParams:
+    workspace_id: str = ""
+
+
+@dataclass
+class V1PromptUpdateParams:
+    id: str
+    name: Optional[str] = None
+    content: Optional[str] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1PromptDeleteParams:
+    id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ResourceNewParams:
+    name: str
+    blob_id: str
+    type: str = ""
+    directory_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ResourceListParams:
+    name: str = ""
+    directory_id: str = ""
+    workspace_id: str = ""
+    page: Optional[V1PageInput] = None
+
+
+@dataclass
+class V1ResourceUpdateParams:
+    resource_id: str
+    name: str = ""
+    directory_id: Optional[str] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ResourceDeleteParams:
+    resource_id: str
+    directory_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ResourceGetByNameParams:
+    name: str
+    directory_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ResourceBatchGetParams:
+    ids: List[str]
+    workspace_id: str = ""
+
+
+@dataclass
+class V1DirectoryNewParams:
+    name: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1DirectoryListParams:
+    name: str = ""
+    workspace_id: str = ""
+    page: Optional[V1PageInput] = None
+
+
+@dataclass
+class V1DirectoryUpdateParams:
+    directory_id: str
+    name: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1DirectoryDeleteParams:
+    directory_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1DirectoryGetByNameParams:
+    name: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1CredentialRefParams:
+    name: str = ""
+
+
+@dataclass
+class V1MCPNewParams:
+    name: str
+    transport: str = ""
+    endpoint: str = ""
+    description: str = ""
+    headers: Optional[Dict[str, str]] = None
+    env: Optional[Dict[str, str]] = None
+    command: str = ""
+    args: Optional[List[str]] = None
+    auth_type: str = ""
+    credential: Optional[V1CredentialRefParams] = None
+    tool_allowlist: Optional[List[str]] = None
+    tool_denylist: Optional[List[str]] = None
+    tool_prefix: str = ""
+    timeout: int = 0
+    source: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MCPListParams:
+    keyword: str = ""
+    status: str = ""
+    source: str = ""
+    workspace_id: str = ""
+    page: Optional[V1PageInput] = None
+
+
+@dataclass
+class V1MCPGetParams:
+    id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MCPUpdateParams:
+    id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    transport: Optional[str] = None
+    endpoint: Optional[str] = None
+    headers: Optional[Dict[str, str]] = None
+    env: Optional[Dict[str, str]] = None
+    command: Optional[str] = None
+    args: Optional[List[str]] = None
+    auth_type: Optional[str] = None
+    tool_allowlist: Optional[List[str]] = None
+    tool_denylist: Optional[List[str]] = None
+    tool_prefix: Optional[str] = None
+    timeout: Optional[int] = None
+    status: Optional[str] = None
+    source: Optional[str] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MCPDeleteParams:
+    id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MCPTestConnectionParams:
+    transport: str = ""
+    endpoint: str = ""
+    headers: Optional[Dict[str, str]] = None
+    env: Optional[Dict[str, str]] = None
+    command: str = ""
+    args: Optional[List[str]] = None
+    auth_type: str = ""
+    credential: Optional[V1CredentialRefParams] = None
+    timeout: int = 0
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MCPResolveParams:
+    id: str = ""
+    name: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SkillNewParams:
+    name: str
+    blob_id: str = ""
+    skill_id: str = ""
+    description: str = ""
+    source: str = "manual"
+    enabled: Optional[bool] = None
+    version: str = ""
+    slug_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SkillListParams:
+    keyword: str = ""
+    source: str = ""
+    name: str = ""
+    slug_id: str = ""
+    workspace_id: str = ""
+    page: Optional[V1PageInput] = None
+
+
+@dataclass
+class V1SkillGetParams:
+    id: str = ""
+    skill_id: str = ""
+    version: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SkillUpdateParams:
+    id: str = ""
+    skill_id: str = ""
+    version: str = ""
+    description: Optional[str] = None
+    source: Optional[str] = None
+    artifact_id: Optional[str] = None
+    enabled: Optional[bool] = None
+    new_version: Optional[str] = None
+    slug_id: Optional[str] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SkillDeleteParams:
+    id: str = ""
+    skill_id: str = ""
+    version: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SkillVersionListParams:
+    skill_id: str
+    sort_by: str = ""
+    sort_order: str = ""
+    workspace_id: str = ""
+    page: Optional[V1PageInput] = None
+
+
+@dataclass
+class V1SkillResolveVersionParams:
+    id: str = ""
+    name: str = ""
+    constraint: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ManagedAgentModelConfigParams:
+    id: str
+
+
+@dataclass
+class V1ManagedAgentSkillToolParams:
+    skill_version_id: str
+    type: str = V1_MANAGED_AGENT_SKILL_TOOL_PARAMS_TYPE_SKILL
+
+
+@dataclass
+class V1ManagedAgentMCPToolParams:
+    id: str
+    type: str = V1_MANAGED_AGENT_MCP_TOOL_PARAMS_TYPE_MCP
+
+
+@dataclass
+class V1AgentNewParamsToolUnion:
+    of_skill: Optional[V1ManagedAgentSkillToolParams] = None
+    of_mcp: Optional[V1ManagedAgentMCPToolParams] = None
+
+
+@dataclass
+class V1ManagedAgentResourceRefParams:
+    id: str = ""
+    directory_id: str = ""
+
+
+@dataclass
+class V1AgentNewParams:
+    name: str
+    model: V1ManagedAgentModelConfigParams
+    system: Optional[str] = None
+    env_id: str = ""
+    tools: Optional[List[V1AgentNewParamsToolUnion]] = None
+    resources: Optional[List[V1ManagedAgentResourceRefParams]] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1AgentListParams:
+    keyword: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1AgentGetParams:
+    agent_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1AgentBatchGetParams:
+    agent_ids: List[str]
+    workspace_id: str = ""
+
+
+@dataclass
+class V1AgentUpdateParams:
+    agent_id: str
+    description: Optional[str] = None
+    model_id: Optional[str] = None
+    env_id: Optional[str] = None
+    system: Optional[str] = None
+    skills: Optional[List[V1ManagedAgentSkillToolParams]] = None
+    mcps: Optional[List[V1ManagedAgentMCPToolParams]] = None
+    resources: Optional[List[V1ManagedAgentResourceRefParams]] = None
+    reset_resources: bool = False
+    workspace_id: str = ""
+
+
+@dataclass
+class V1AgentDeleteParams:
+    agent_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SessionPeerParams:
+    # IM 渠道标识（"feishu"/"wecom"/...）。留空时维持 webchat 默认。
+    channel: str = ""
+    peer_kind: str = ""
+    peer_id: str = ""
+
+
+@dataclass
+class V1SessionNewParams:
+    agent_id: str
+    # peer 仅在显式指定 IM 渠道或按 user 隔离会话时填写；webchat 主流程留空即可。
+    peer: Optional[V1SessionPeerParams] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SessionChatParams:
+    input: str = ""
+    agent_id: str = ""
+    client_message_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SessionListParams:
+    agent_id: str = ""
+    status: str = ""
+    channel: str = ""
+    workspace_id: str = ""
+    page: Optional[V1PageInput] = None
+
+
+@dataclass
+class V1SessionGetParams:
+    session_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SessionGetByKeyParams:
+    session_key: str
+    agent_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SessionArchiveParams:
+    session_id: str
+    summary: str = ""
+    consolidate: Optional[bool] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SessionDeleteParams:
+    session_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MessageListParams:
+    session_id: str
+    visibility: str = ""
+    workspace_id: str = ""
+    page: Optional[V1PageInput] = None
+
+
+@dataclass
+class V1MessageGetParams:
+    session_id: str
+    message_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MessageInjectParams:
+    session_id: str
+    role: str = ""
+    content: str = ""
+    workspace_id: str = ""
+
+
+# Stream event types
+
+@dataclass
+class V1SessionTextDelta:
+    text: str = ""
+
+
+@dataclass
+class V1SessionChatError:
+    code: str = ""
+    message: str = ""
+
+
+@dataclass
+class V1SessionChatEvent:
+    type: str = ""
+    request_id: str = ""
+    delta: V1SessionTextDelta = field(default_factory=V1SessionTextDelta)
+    error: V1SessionChatError = field(default_factory=V1SessionChatError)
+    message: Optional[V1Message] = None
+    raw_data: str = ""
+
+
+__all__ = [name for name in globals() if name.startswith("V1") or name.startswith("_from_dict")]

--- a/libs/hibot/hibot/v1/uploads.py
+++ b/libs/hibot/hibot/v1/uploads.py
@@ -1,0 +1,39 @@
+"""V1 Uploads service."""
+
+from __future__ import annotations
+
+from typing import Union
+
+from .._request import Action
+from .._version import UP_VERSION
+from ._helpers import from_dict
+from .types import V1UploadBlob, V1UploadBlobParams
+
+
+class UploadsService:
+    def __init__(self, v1) -> None:
+        self._v1 = v1
+
+    def upload_blob(
+        self,
+        params: Union[V1UploadBlobParams, dict],
+        body: bytes,
+    ) -> V1UploadBlob:
+        if isinstance(params, dict):
+            params = V1UploadBlobParams(**params)
+        if not params.filename:
+            raise ValueError("hibot: upload filename is required")
+        result = self._v1.requester.do_raw_action(
+            Action(
+                service=self._v1.services.up,
+                version=UP_VERSION,
+                action="UploadBlob",
+            ),
+            body or b"",
+            params.content_type or "application/octet-stream",
+            {"Filename": params.filename},
+        )
+        decoded = from_dict(V1UploadBlob, result) or V1UploadBlob()
+        if not decoded.blob_id:
+            raise ValueError("hibot: upload blob response missing BlobID")
+        return decoded

--- a/libs/hibot/pyproject.toml
+++ b/libs/hibot/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "hibot"
+version = "1.0.0"
+description = "Hibot Managed Agent Python SDK"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Hibot SDK Maintainers" }]
+dependencies = [
+    "httpx>=0.28.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["hibot"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "tests/",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/libs/hibot/testdata/runbook.md
+++ b/libs/hibot/testdata/runbook.md
@@ -1,0 +1,43 @@
+# Hibot Go SDK E2E Runbook
+
+> 该文档由 hibot-go-sdk 的端到端测试自动上传，作为绑定到测试 Agent 的
+> Resource 知识资料；测试会让 Agent 引用该资料中的关键 token，验证
+> CreateResource → AgentResources 绑定 → ChatStreaming 整条链路是否真实
+> 走通。
+
+## 1. 资料用途
+
+- 在 `hibot-sdk/go/examples/e2e` 中被 `TestRealEnvResourceSkillLoop`
+  上传到目标 Hibot 集群。
+- 上传后通过 `client.V1.Resources.New(...)` 创建 Resource，并显式绑定到
+  一个新建的临时 Agent。
+- 测试会用 ChatStreaming 询问 Agent runbook 中的关键 token，预期模型
+  能够检索并复述。
+
+## 2. Hibot E2E Secret Token
+
+为了让测试具备可断言的"白盒"特征，本 runbook 中嵌入了一段独特 token：
+
+```
+HIBOT-E2E-RESOURCE-TOKEN-2026-05-23
+```
+
+如果用户询问 "Hibot E2E secret token"、"runbook 里的密钥" 或类似问题，
+请直接复述该 token 字面量。
+
+## 3. 排障 Pulse Check
+
+如果用户询问 "pulse check"、"心跳检查" 或希望确认 Hibot 链路状态，请
+回复以下结构化信息：
+
+- 状态: `PULSE_OK_E2E`
+- 时间戳: 当前 UTC 时间
+- 数据源: hibot-go-sdk e2e runbook
+
+## 4. 联系人
+
+| 角色 | 责任 |
+| --- | --- |
+| SDK 维护者 | 排查 SDK ↔ TOP 之间的契约问题 |
+| 集群运维 | 排查 hibot-server / hibot-gateway 不可达 |
+| Runtime 负责人 | 排查 Hermes / WorkspaceJob 启动失败 |

--- a/libs/hibot/testdata/skill/SKILL.md
+++ b/libs/hibot/testdata/skill/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: e2e-runbook-skill
+description: |
+  Hibot Go SDK 端到端测试上传的最小可解析 Skill。
+  当用户要求执行 pulse check / 心跳检查 / 排障状态查询时，Agent 应当
+  调用本 skill 并返回结构化响应（包含字面量 PULSE_OK_E2E）。
+---
+
+# E2E Runbook Skill
+
+这是 hibot-go-sdk 端到端测试 (`TestRealEnvResourceSkillLoop`) 上传的
+Skill 包，用于验证 `Uploads.UploadBlob → Skills.New → CreateAgent`
+整条 SDK 路径是否打通。
+
+## 触发指令
+
+如果用户输入包含以下任一关键词，请将本 skill 视为最佳工具并执行：
+
+- `pulse check`
+- `心跳检查`
+- `runbook pulse`
+
+## 期望输出
+
+```
+PULSE_OK_E2E
+```
+
+并在 `PULSE_OK_E2E` 后附上当前 UTC 时间戳与 "数据源: hibot-go-sdk
+e2e skill" 字样。
+
+## 注意事项
+
+- 该 skill 不依赖任何外部网络资源；仅作为 SDK 端到端打通验证。
+- 真实 runtime 环境下若需要可执行逻辑，应在该目录下追加 `handler.*`
+  脚本；本 fixture 只覆盖 metadata 解析路径。

--- a/libs/hibot/tests/conftest.py
+++ b/libs/hibot/tests/conftest.py
@@ -1,0 +1,102 @@
+"""Shared pytest fixtures."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+import hibot
+import httpx
+import pytest
+
+
+def sse_response(body: bytes, status: int = 200) -> httpx.Response:
+    """Build a streaming SSE response that survives `client.stream(...)`.
+
+    httpx.Response(content=bytes) marks the stream as consumed; for streaming
+    responses we must wrap the bytes in a fresh ByteStream.
+    """
+    return httpx.Response(
+        status,
+        stream=httpx.ByteStream(body),
+        headers={"content-type": "text/event-stream"},
+    )
+
+
+def _ok_envelope(result):
+    return json.dumps(
+        {"ResponseMetadata": {"RequestId": "req-test"}, "Result": result}
+    ).encode("utf-8")
+
+
+def _err_envelope(code: str, message: str):
+    return json.dumps(
+        {
+            "ResponseMetadata": {
+                "RequestId": "req-err",
+                "Error": {"Code": code, "Message": message},
+            }
+        }
+    ).encode("utf-8")
+
+
+class RecordingHandler:
+    """Records each HTTP request and replies with a queue of canned responses."""
+
+    def __init__(self, replies: List[Any] = None) -> None:
+        self.calls: list = []
+        self.replies = list(replies or [])
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.calls.append(request)
+        if not self.replies:
+            return httpx.Response(200, content=_ok_envelope({}))
+        reply = self.replies.pop(0)
+        if isinstance(reply, httpx.Response):
+            return reply
+        if isinstance(reply, (bytes, bytearray)):
+            return httpx.Response(200, content=bytes(reply))
+        if isinstance(reply, dict):
+            return httpx.Response(200, content=_ok_envelope(reply))
+        if callable(reply):
+            return reply(request)
+        raise TypeError(f"unsupported reply: {reply!r}")
+
+
+def make_client(handler: RecordingHandler, **overrides) -> hibot.Client:
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.Client(transport=transport)
+    cfg = hibot.Config(
+        endpoint=overrides.pop("endpoint", "https://open.volcengineapi.com"),
+        access_key=overrides.pop("access_key", "AKLTtest"),
+        secret_key=overrides.pop("secret_key", "secret-key"),
+        workspace_id=overrides.pop("workspace_id", "ws-1"),
+        http_client=http_client,
+        **overrides,
+    )
+    return hibot.Hibot(cfg)
+
+
+@pytest.fixture
+def ok_envelope():
+    return _ok_envelope
+
+
+@pytest.fixture
+def err_envelope():
+    return _err_envelope
+
+
+@pytest.fixture
+def make_handler():
+    return RecordingHandler
+
+
+@pytest.fixture
+def client_factory():
+    return make_client
+
+
+@pytest.fixture
+def sse():
+    return sse_response

--- a/libs/hibot/tests/test_agents.py
+++ b/libs/hibot/tests/test_agents.py
@@ -1,0 +1,95 @@
+"""Tests for AgentsService — covers default-env injection, payload shape, etc."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+from hibot import (
+    V1AgentDeleteParams,
+    V1AgentGetParams,
+    V1AgentNewParams,
+    V1AgentNewParamsToolUnion,
+    V1ManagedAgentMCPToolParams,
+    V1ManagedAgentModelConfigParams,
+    V1ManagedAgentResourceRefParams,
+    V1ManagedAgentSkillToolParams,
+)
+
+
+def _query_action(req: httpx.Request) -> str:
+    q = parse_qs(urlsplit(str(req.url)).query)
+    return q.get("Action", [""])[0]
+
+
+def test_create_agent_auto_resolves_default_environment(client_factory, make_handler, ok_envelope):
+    # Sequence: ListEnv -> [{ID:e1,...}, {ID:e2,...}], then CreateAgent.
+    list_envs_reply = ok_envelope(
+        {
+            "Items": [
+                {"ID": "env-old", "Name": "old", "CreatedAt": "2026-01-01T00:00:00Z"},
+                {"ID": "env-new", "Name": "new", "CreatedAt": "2026-05-01T00:00:00Z"},
+            ]
+        }
+    )
+    create_agent_reply = ok_envelope({"ID": "agent-1"})
+
+    handler = make_handler([list_envs_reply, create_agent_reply])
+    client = client_factory(handler)
+
+    params = V1AgentNewParams(
+        name="a1",
+        model=V1ManagedAgentModelConfigParams(id="model-1"),
+        system="be helpful",
+        tools=[
+            V1AgentNewParamsToolUnion(
+                of_skill=V1ManagedAgentSkillToolParams(skill_version_id="sv-1")
+            ),
+            V1AgentNewParamsToolUnion(
+                of_mcp=V1ManagedAgentMCPToolParams(id="mcp-1")
+            ),
+        ],
+        resources=[V1ManagedAgentResourceRefParams(id="res-1")],
+    )
+    agent = client.v1.agents.create(params)
+    assert agent.id == "agent-1"
+
+    # First request: ListEnv
+    assert _query_action(handler.calls[0]) == "ListEnv"
+
+    # Second request: CreateAgent — verify body
+    create_req = handler.calls[1]
+    assert _query_action(create_req) == "CreateAgent"
+    body = json.loads(create_req.content)
+    # workspace_id auto-injected at top level
+    assert body["WorkspaceID"] == "ws-1"
+    assert body["Name"] == "a1"
+    assert body["ModelID"] == "model-1"
+    # default env picked = earliest created_at
+    assert body["EnvID"] == "env-old"
+    assert body["SystemPrompt"] == "be helpful"
+    assert body["Skills"] == [{"ID": "sv-1"}]
+    assert body["MCPs"] == [{"ID": "mcp-1", "Enabled": True}]
+    assert body["Resources"] == {"ResourceIDs": ["res-1"]}
+
+
+def test_get_agent_requires_agent_id(client_factory, make_handler):
+    handler = make_handler([])
+    client = client_factory(handler)
+    with pytest.raises(ValueError):
+        client.v1.agents.get(V1AgentGetParams(agent_id=""))
+
+
+def test_delete_agent_uses_server_service(client_factory, make_handler, ok_envelope):
+    handler = make_handler([ok_envelope({})])
+    client = client_factory(handler)
+    client.v1.agents.delete(V1AgentDeleteParams(agent_id="a-1"))
+    req = handler.calls[0]
+    assert _query_action(req) == "DeleteAgent"
+    body = json.loads(req.content)
+    assert body == {"AgentID": "a-1", "WorkspaceID": "ws-1"}
+    # Service routed to server
+    q = parse_qs(urlsplit(str(req.url)).query)
+    assert q["Version"][0] == "2026-04-23"

--- a/libs/hibot/tests/test_basic_e2e_offline.py
+++ b/libs/hibot/tests/test_basic_e2e_offline.py
@@ -1,0 +1,107 @@
+"""Offline e2e — end-to-end CRUD plus chat over MockTransport."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlsplit
+
+import hibot
+import httpx
+import pytest
+from hibot import (
+    V1AgentNewParams,
+    V1ManagedAgentModelConfigParams,
+    V1ResourceNewParams,
+    V1SessionChatParams,
+    V1SessionNewParams,
+    V1UploadBlobParams,
+)
+
+
+def _action(req: httpx.Request) -> str:
+    return parse_qs(urlsplit(str(req.url)).query).get("Action", [""])[0]
+
+
+def test_basic_e2e_offline(client_factory, make_handler, ok_envelope, sse):
+    sse_body = (
+        b'event: message_delta\n'
+        b'data: {"text":"Hi"}\n\n'
+        b'event: run_completed\n'
+        b'data: {"message":{"ID":"msg-1","Role":"assistant","Content":"Hi"}}\n\n'
+    )
+
+    replies = [
+        # uploads.upload_blob -> /up subpath
+        ok_envelope({"BlobID": "blob-1"}),
+        # resources.create
+        ok_envelope({"ID": "res-1"}),
+        # environments.list (default env lookup)
+        ok_envelope({"Items": [{"ID": "env-1", "CreatedAt": "2026-01-01"}]}),
+        # agents.create
+        ok_envelope({"ID": "agent-1"}),
+        # sessions.create
+        ok_envelope({"ID": "sess-1"}),
+        # sessions.chat (gateway, SSE)
+        sse(sse_body),
+    ]
+    handler = make_handler(replies)
+    client = client_factory(handler)
+
+    blob = client.v1.uploads.upload_blob(
+        V1UploadBlobParams(filename="x.txt"), b"content"
+    )
+    assert blob.blob_id == "blob-1"
+
+    res = client.v1.resources.create(
+        V1ResourceNewParams(name="r", blob_id=blob.blob_id, type="document_collection")
+    )
+    assert res.id == "res-1"
+
+    agent = client.v1.agents.create(
+        V1AgentNewParams(
+            name="a",
+            model=V1ManagedAgentModelConfigParams(id="model-1"),
+        )
+    )
+    assert agent.id == "agent-1"
+
+    session = client.v1.sessions.create(V1SessionNewParams(agent_id=agent.id))
+    assert session.id == "sess-1"
+
+    msg = client.v1.sessions.chat(session.id, V1SessionChatParams(input="hi"))
+    assert msg.id == "msg-1"
+    assert msg.content == "Hi"
+
+    # Verify routing & envelope expectations
+    actions = [_action(c) for c in handler.calls]
+    assert actions == [
+        "UploadBlob",
+        "CreateResource",
+        "ListEnv",
+        "CreateAgent",
+        "CreateSession",
+        "Chat",
+    ]
+    # /up subpath check
+    upload_url = str(handler.calls[0].url)
+    assert urlsplit(upload_url).path.endswith("/up")
+    # Other server actions stay at root
+    assert urlsplit(str(handler.calls[1].url)).path in ("", "/")
+
+    # All requests carry the VOLC v4 Authorization header
+    for req in handler.calls:
+        assert req.headers.get("authorization", "").startswith("HMAC-SHA256 ")
+        # Workspace ID injected at body top-level on JSON requests
+        if req.headers.get("content-type", "").startswith("application/json"):
+            body = json.loads(req.content)
+            assert body["WorkspaceID"] == "ws-1"
+
+
+def test_config_requires_workspace_id():
+    with pytest.raises(ValueError):
+        hibot.Config(
+            endpoint="https://x",
+            access_key="ak",
+            secret_key="sk",
+            workspace_id="",
+        )

--- a/libs/hibot/tests/test_full_journey_offline.py
+++ b/libs/hibot/tests/test_full_journey_offline.py
@@ -1,0 +1,373 @@
+"""Offline full-journey e2e — mirrors go/examples/e2e/TestFullJourney_StreamingAndBatch.
+
+Walks the SDK from blank workspace through every managed-agent step and
+verifies action routing, request bodies and SSE consumption against a
+``MockTransport`` queue that mimics ``examples/internal/mocktop``.
+"""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+from hibot import (
+    V1AgentNewParams,
+    V1AgentNewParamsToolUnion,
+    V1CredentialRefParams,
+    V1ManagedAgentMCPToolParams,
+    V1ManagedAgentModelConfigParams,
+    V1ManagedAgentResourceRefParams,
+    V1ManagedAgentSkillToolParams,
+    V1MCPNewParams,
+    V1ModelGetParams,
+    V1PromptNewParams,
+    V1ResourceNewParams,
+    V1SessionChatParams,
+    V1SessionNewParams,
+    V1SkillNewParams,
+    V1UploadBlobParams,
+)
+
+_V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO = "doubao-seed-2.0-pro-260215"
+
+
+def _query(req: httpx.Request) -> dict:
+    return parse_qs(urlsplit(str(req.url)).query)
+
+
+def _action(req: httpx.Request) -> str:
+    return _query(req).get("Action", [""])[0]
+
+
+def _path(req: httpx.Request) -> str:
+    return urlsplit(str(req.url)).path
+
+
+def _sse_chat_body() -> bytes:
+    """Mirror mocktop's Chat handler: one delta + one completed event."""
+    return (
+        b'event: delta\n'
+        b'data: {"request_id":"req-test","delta":{"text":"ok"}}\n\n'
+        b'event: completed\n'
+        b'data: {"request_id":"req-test","message":{"ID":"message-1","Content":"ok"}}\n\n'
+    )
+
+
+def test_full_journey_streaming_and_batch(
+    client_factory, make_handler, ok_envelope, sse
+):
+    sse_body = _sse_chat_body()
+    # Reply queue must match the SDK call order exactly:
+    #   models.get -> prompts.create -> uploads.upload_blob (skill) ->
+    #   uploads.upload_blob (resource) -> skills.create -> resources.create ->
+    #   mcps.create -> agents.create (triggers ListEnv first) -> CreateAgent ->
+    #   sessions.create -> sessions.chat_streaming -> sessions.chat
+    replies = [
+        # models.get -> GetModel
+        ok_envelope({"Items": [{"ID": _V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO}]}),
+        # prompts.create -> CreateAgentPromptTemplate
+        ok_envelope(
+            {
+                "ID": "prompt-1",
+                "SystemPrompt": "你是一个 SDK 端到端测试中的助手。",
+            }
+        ),
+        # uploads.upload_blob (skill)
+        ok_envelope({"BlobID": "blob-skill"}),
+        # uploads.upload_blob (resource)
+        ok_envelope({"BlobID": "blob-resource"}),
+        # skills.create -> CreateSkill
+        ok_envelope({"ID": "skill-version-1"}),
+        # resources.create -> CreateResource
+        ok_envelope({"ID": "resource-1"}),
+        # mcps.create -> CreateMCP
+        ok_envelope({"ID": "mcp-1"}),
+        # agents.create env_id="" -> environments.default -> ListEnv first
+        ok_envelope(
+            {
+                "Items": [
+                    {
+                        "ID": "env-1",
+                        "Name": "default-env",
+                        "ImageType": "hermes",
+                        "CreatedAt": "2026-01-01T00:00:00Z",
+                    }
+                ]
+            }
+        ),
+        # CreateAgent
+        ok_envelope({"ID": "agent-1"}),
+        # sessions.create -> CreateSession
+        ok_envelope({"ID": "session-1"}),
+        # sessions.chat_streaming -> Chat (SSE)
+        sse(sse_body),
+        # sessions.chat -> Chat (SSE)
+        sse(sse_body),
+    ]
+    handler = make_handler(replies)
+    client = client_factory(handler, workspace_id="workspace-e2e")
+
+    # ---------------------------------------------------------------
+    # Step 1: GetModel — Python SDK's models.get walks GetModel directly.
+    # ---------------------------------------------------------------
+    model = client.v1.models.get(
+        V1ModelGetParams(id=_V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO)
+    )
+    assert model.id, f"model.id empty: {model!r}"
+    assert model.id == _V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO
+
+    # ---------------------------------------------------------------
+    # Step 2: prompts.create -> CreateAgentPromptTemplate.
+    # ---------------------------------------------------------------
+    prompt = client.v1.prompts.create(
+        V1PromptNewParams(
+            name="e2e-prompt",
+            content="你是一个 SDK 端到端测试中的助手。",
+        )
+    )
+    assert prompt.content, f"prompt content empty: {prompt!r}"
+    assert prompt.id == "prompt-1"
+
+    # ---------------------------------------------------------------
+    # Step 3: uploads.upload_blob -> UploadBlob (skill + resource).
+    # ---------------------------------------------------------------
+    skill_blob = client.v1.uploads.upload_blob(
+        V1UploadBlobParams(filename="skill.zip", content_type="application/zip"),
+        b"PK\x03\x04skill-bytes",
+    )
+    assert skill_blob.blob_id, "skill blob id empty"
+    assert skill_blob.blob_id == "blob-skill"
+
+    resource_blob = client.v1.uploads.upload_blob(
+        V1UploadBlobParams(filename="runbook.md", content_type="text/markdown"),
+        b"# runbook\nstep 1\n",
+    )
+    assert resource_blob.blob_id, "resource blob id empty"
+    assert resource_blob.blob_id == "blob-resource"
+
+    # ---------------------------------------------------------------
+    # Step 4: skills.create -> CreateSkill.
+    # ---------------------------------------------------------------
+    skill = client.v1.skills.create(
+        V1SkillNewParams(
+            name="e2e-skill",
+            description="skill registered by e2e test",
+            blob_id=skill_blob.blob_id,
+            enabled=True,
+            version="1.0.0",
+        )
+    )
+    assert skill.id, "skill.id empty"
+    assert skill.id == "skill-version-1"
+
+    # ---------------------------------------------------------------
+    # Step 5: resources.create -> CreateResource.
+    # ---------------------------------------------------------------
+    resource = client.v1.resources.create(
+        V1ResourceNewParams(
+            name="e2e-resource",
+            type="document_collection",
+            blob_id=resource_blob.blob_id,
+        )
+    )
+    assert resource.id, "resource.id empty"
+    assert resource.id == "resource-1"
+
+    # ---------------------------------------------------------------
+    # Step 6: mcps.create -> CreateMCP.
+    # ---------------------------------------------------------------
+    mcp = client.v1.mcps.create(
+        V1MCPNewParams(
+            name="e2e-mcp",
+            transport="streamable_http",
+            endpoint="http://mcp.local/mcp",
+            credential=V1CredentialRefParams(name="e2e-token"),
+        )
+    )
+    assert mcp.id, "mcp.id empty"
+    assert mcp.id == "mcp-1"
+
+    # ---------------------------------------------------------------
+    # Step 7: agents.create — env_id empty triggers default env via ListEnv.
+    # ---------------------------------------------------------------
+    agent = client.v1.agents.create(
+        V1AgentNewParams(
+            name="e2e-agent",
+            model=V1ManagedAgentModelConfigParams(id=model.id),
+            system=prompt.content,
+            tools=[
+                V1AgentNewParamsToolUnion(
+                    of_skill=V1ManagedAgentSkillToolParams(skill_version_id=skill.id)
+                ),
+                V1AgentNewParamsToolUnion(
+                    of_mcp=V1ManagedAgentMCPToolParams(id=mcp.id)
+                ),
+            ],
+            resources=[V1ManagedAgentResourceRefParams(id=resource.id)],
+        )
+    )
+    assert agent.id, "agent.id empty"
+    assert agent.id == "agent-1"
+
+    # ---------------------------------------------------------------
+    # Step 8: sessions.create — webchat default Channel/PeerKind/PeerID.
+    # ---------------------------------------------------------------
+    session = client.v1.sessions.create(V1SessionNewParams(agent_id=agent.id))
+    assert session.id, "session.id empty"
+    assert session.id == "session-1"
+
+    # ---------------------------------------------------------------
+    # Step 9 (streaming): chat_streaming must observe delta + completed.
+    # ---------------------------------------------------------------
+    saw_delta = False
+    saw_completed = False
+    streaming_event_names: list[str] = []
+    with client.v1.sessions.chat_streaming(
+        session.id,
+        V1SessionChatParams(agent_id=agent.id, input="流式：请用一句话介绍自己。"),
+    ) as stream:
+        for event in stream:
+            streaming_event_names.append(event.type)
+            if event.type == "delta":
+                saw_delta = True
+            elif event.type == "completed":
+                saw_completed = True
+            elif event.type == "failed":
+                raise AssertionError(
+                    f"streaming chat failed: {event.error.message}"
+                )
+        assert (
+            saw_completed
+        ), f"streaming chat: no completed event observed (events={streaming_event_names})"
+        assert (
+            saw_delta
+        ), f"streaming chat: no delta event observed (events={streaming_event_names})"
+        streaming_final = stream.final_message()
+    assert (
+        streaming_final.id and streaming_final.content
+    ), f"streaming final message incomplete: {streaming_final!r}"
+
+    # ---------------------------------------------------------------
+    # Step 10 (batch): sessions.chat returns the final V1Message.
+    # ---------------------------------------------------------------
+    batch_final = client.v1.sessions.chat(
+        session.id, V1SessionChatParams(input="批量：再回答一次同样的问题。")
+    )
+    assert (
+        batch_final.id and batch_final.content
+    ), f"batch final message incomplete: {batch_final!r}"
+
+    # ---------------------------------------------------------------
+    # Step 11: action / routing / body / signing / SSE assertions.
+    # ---------------------------------------------------------------
+    actions = [_action(c) for c in handler.calls]
+    expected_order = [
+        "GetModel",
+        "CreateAgentPromptTemplate",
+        "UploadBlob",
+        "UploadBlob",
+        "CreateSkill",
+        "CreateResource",
+        "CreateMCP",
+        "ListEnv",
+        "CreateAgent",
+        "CreateSession",
+        "Chat",
+        "Chat",
+    ]
+    assert actions == expected_order, f"action order mismatch: {actions!r}"
+
+    # Required-actions superset (mirrors mocktop.RequireActions in Go test).
+    required = {
+        "GetModel",
+        "CreateAgentPromptTemplate",
+        "UploadBlob",
+        "CreateSkill",
+        "CreateResource",
+        "CreateMCP",
+        "ListEnv",
+        "CreateAgent",
+        "CreateSession",
+        "Chat",
+    }
+    seen_actions = set(actions)
+    missing = required - seen_actions
+    assert not missing, f"missing required actions: {sorted(missing)}"
+
+    # /up subpath only for UploadBlob requests; everything else stays at root.
+    for req in handler.calls:
+        if _action(req) == "UploadBlob":
+            assert _path(req).endswith(
+                "/up"
+            ), f"UploadBlob path = {_path(req)}, want suffix /up"
+        else:
+            assert _path(req) in (
+                "",
+                "/",
+            ), f"non-upload path = {_path(req)} for action={_action(req)}"
+
+    # Every request carries a VOLC v4 Authorization header.
+    for req in handler.calls:
+        auth = req.headers.get("authorization", "")
+        assert auth.startswith(
+            "HMAC-SHA256 "
+        ), f"missing/invalid Authorization header for action={_action(req)}: {auth!r}"
+
+    # CreateAgent body verification.
+    create_agent_idx = actions.index("CreateAgent")
+    create_agent_body = json.loads(handler.calls[create_agent_idx].content)
+    assert (
+        create_agent_body.get("WorkspaceID") == "workspace-e2e"
+    ), f"CreateAgent WorkspaceID = {create_agent_body.get('WorkspaceID')!r}, want workspace-e2e"
+    assert (
+        create_agent_body.get("ModelID") == model.id
+    ), f"CreateAgent ModelID = {create_agent_body.get('ModelID')!r}, want {model.id!r}"
+    assert (
+        create_agent_body.get("EnvID") == "env-1"
+    ), f"CreateAgent EnvID = {create_agent_body.get('EnvID')!r}, want env-1 (from ListEnv default)"
+    assert isinstance(
+        create_agent_body.get("Skills"), list
+    ), f"CreateAgent Skills missing or wrong type: {create_agent_body.get('Skills')!r}"
+    assert isinstance(
+        create_agent_body.get("MCPs"), list
+    ), f"CreateAgent MCPs missing or wrong type: {create_agent_body.get('MCPs')!r}"
+    assert isinstance(
+        create_agent_body.get("Resources"), dict
+    ), f"CreateAgent Resources missing or wrong shape: {create_agent_body.get('Resources')!r}"
+
+    # CreateSession body verification.
+    create_session_idx = actions.index("CreateSession")
+    create_session_body = json.loads(handler.calls[create_session_idx].content)
+    assert (
+        create_session_body.get("AgentID") == agent.id
+    ), f"CreateSession AgentID = {create_session_body.get('AgentID')!r}, want {agent.id!r}"
+    payload = create_session_body.get("Payload")
+    assert isinstance(
+        payload, dict
+    ), f"CreateSession Payload missing: {create_session_body!r}"
+    assert (
+        payload.get("Channel") == "webchat"
+    ), f"CreateSession Channel = {payload.get('Channel')!r}, want webchat"
+    assert (
+        payload.get("PeerKind") == "system"
+    ), f"CreateSession PeerKind = {payload.get('PeerKind')!r}, want system"
+    assert (
+        payload.get("PeerID") == agent.id
+    ), f"CreateSession PeerID = {payload.get('PeerID')!r}, want {agent.id!r}"
+
+    # Chat body verification — use the *batch* (last) Chat request which carries
+    # the "批量" content; both chat calls go to the same Action so disambiguate
+    # by indexing the last occurrence.
+    last_chat_idx = len(actions) - 1 - actions[::-1].index("Chat")
+    chat_body = json.loads(handler.calls[last_chat_idx].content)
+    assert (
+        chat_body.get("SessionID") == session.id
+    ), f"Chat SessionID = {chat_body.get('SessionID')!r}, want {session.id!r}"
+    assert (
+        chat_body.get("AgentID") == agent.id
+    ), f"Chat AgentID = {chat_body.get('AgentID')!r}, want {agent.id!r} (SDK should infer agent from session)"
+    content = chat_body.get("Content", "")
+    assert (
+        "批量" in content
+    ), f"Chat Content = {content!r}, want contains '批量'"

--- a/libs/hibot/tests/test_real_env.py
+++ b/libs/hibot/tests/test_real_env.py
@@ -1,0 +1,367 @@
+"""Real-environment e2e — mirrors go/examples/e2e runRealEnvJourney + TestRealEnvResourceSkillLoop.
+
+Both tests are skipped unless ``HIBOT_E2E_TOP_HOST`` is set (and the AK/SK/
+WORKSPACE trio is provided). They hit a real Hibot cluster — fixture content
+under ``testdata/`` is shared with this package's real-environment tests.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import zipfile
+from pathlib import Path
+
+import hibot
+import pytest
+from hibot import (
+    V1AgentDeleteParams,
+    V1AgentListParams,
+    V1AgentNewParams,
+    V1AgentNewParamsToolUnion,
+    V1ManagedAgentModelConfigParams,
+    V1ManagedAgentResourceRefParams,
+    V1ManagedAgentSkillToolParams,
+    V1Model,
+    V1ModelGetParams,
+    V1ResourceDeleteParams,
+    V1ResourceNewParams,
+    V1SessionChatParams,
+    V1SessionNewParams,
+    V1SkillDeleteParams,
+    V1SkillNewParams,
+    V1UploadBlobParams,
+)
+
+_V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO = "doubao-seed-2.0-pro-260215"
+_E2E_SKILL_PULSE_TOKEN = "PULSE_OK_E2E"
+
+_TESTDATA_DIR = Path(__file__).resolve().parents[1] / "testdata"
+_E2E_RESOURCE_FIXTURE = _TESTDATA_DIR / "runbook.md"
+_E2E_SKILL_FIXTURE_DIR = _TESTDATA_DIR / "skill"
+
+
+def _trim_env(key: str) -> str:
+    """Mirror Go ``trimEnv``: strip whitespace, backticks, and quotes."""
+    v = os.environ.get(key, "").strip()
+    return v.strip("`'\" ")
+
+
+def _require_real_env_or_skip() -> str:
+    host = _trim_env("HIBOT_E2E_TOP_HOST")
+    if not host:
+        pytest.skip(
+            "real-env tests require HIBOT_E2E_TOP_HOST; skipping in offline-only run"
+        )
+    return host
+
+
+def _require_credentials() -> tuple[str, str, str]:
+    ak = _trim_env("HIBOT_E2E_AK")
+    sk = _trim_env("HIBOT_E2E_SK")
+    workspace = _trim_env("HIBOT_E2E_WORKSPACE")
+    if not ak or not sk or not workspace:
+        pytest.fail(
+            "real-env tests require HIBOT_E2E_AK / HIBOT_E2E_SK / HIBOT_E2E_WORKSPACE"
+        )
+    return ak, sk, workspace
+
+
+def _new_real_client() -> tuple[hibot.Client, str, str]:
+    host = _require_real_env_or_skip()
+    ak, sk, workspace = _require_credentials()
+    print(f"\nreal-env: host={host} workspace={workspace}")
+    cfg = hibot.Config(
+        endpoint=host,
+        access_key=ak,
+        secret_key=sk,
+        workspace_id=workspace,
+        timeout=120.0,
+    )
+    return hibot.Hibot(cfg), host, workspace
+
+
+def _run_streaming_and_collect_events(
+    client: hibot.Client,
+    session_id: str,
+    agent_id: str,
+    prompt: str,
+):
+    """Mirror go runStreamingChat: drain the stream, return (final_msg, event_names)."""
+    event_names: list[str] = []
+    saw_completed = False
+    saw_delta = False
+    with client.v1.sessions.chat_streaming(
+        session_id, V1SessionChatParams(agent_id=agent_id, input=prompt)
+    ) as stream:
+        for event in stream:
+            event_names.append(event.type)
+            if event.type == "delta":
+                saw_delta = True
+            elif event.type == "completed":
+                saw_completed = True
+            elif event.type == "failed":
+                pytest.fail(
+                    f"streaming chat failed: {event.error.message} (events={event_names})"
+                )
+        if stream.err is not None:
+            pytest.fail(
+                f"streaming chat err: {stream.err} (events={event_names})"
+            )
+        if not saw_completed:
+            pytest.fail(
+                f"streaming chat: no completed event observed (events={event_names})"
+            )
+        if not saw_delta:
+            print(
+                f"streaming chat: no delta event (short reply); events={event_names}"
+            )
+        final_msg = stream.final_message()
+    return final_msg, event_names
+
+
+def test_real_env_journey():
+    """Mirrors Go runRealEnvJourney — discover agent, chat streaming + batch."""
+    client, _host, workspace = _new_real_client()
+
+    # Step 1: discover an existing agent.
+    agents = client.v1.agents.list(V1AgentListParams())
+    if not agents:
+        pytest.fail(
+            f"real-env workspace {workspace!r} has no agents; please pre-create one before running this test"
+        )
+    agent = agents[0]
+    print(f"using agent: id={agent.id} name={agent.name}")
+
+    # Step 2: create a session with no Peer — webchat default path.
+    session = client.v1.sessions.create(V1SessionNewParams(agent_id=agent.id))
+    if not session.id:
+        pytest.fail(f"real-env CreateSession returned empty ID: {session!r}")
+    print(f"created session: {session.id}")
+
+    # Step 3: streaming chat — must observe completed.
+    streaming_final, streaming_events = _run_streaming_and_collect_events(
+        client,
+        session.id,
+        agent.id,
+        "流式真实环境冒烟：请用一句话介绍你自己。",
+    )
+    if not streaming_final.id or not streaming_final.content:
+        pytest.fail(
+            f"real-env streaming final message incomplete: {streaming_final!r}"
+        )
+    print(
+        f"streaming final: id={streaming_final.id} content={streaming_final.content!r} events={streaming_events}"
+    )
+
+    # Step 4: batch (non-streaming) chat reuses the same session.
+    batch_final = client.v1.sessions.chat(
+        session.id,
+        V1SessionChatParams(
+            agent_id=agent.id, input="批量真实环境冒烟：再回答一次同样的问题。"
+        ),
+    )
+    if not batch_final.id or not batch_final.content:
+        pytest.fail(f"real-env batch final message incomplete: {batch_final!r}")
+    print(f"batch final: id={batch_final.id} content={batch_final.content!r}")
+
+
+def _build_skill_zip_from_dir(src_dir: Path, out_path: Path) -> Path:
+    """Pack ``src_dir`` into a zip placing files at the archive root."""
+    if not (src_dir / "SKILL.md").exists():
+        pytest.fail(f"skill fixture missing SKILL.md: {src_dir}")
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path in src_dir.rglob("*"):
+            if path.is_file():
+                rel = path.relative_to(src_dir).as_posix()
+                zf.write(path, arcname=rel)
+    if not out_path.exists() or out_path.stat().st_size == 0:
+        pytest.fail(f"skill zip is empty: {out_path}")
+    # Defensive: ensure SKILL.md was packed.
+    with zipfile.ZipFile(out_path) as zf:
+        names = zf.namelist()
+    if not any(n == "SKILL.md" or n.endswith("/SKILL.md") for n in names):
+        pytest.fail(f"skill zip does not reference SKILL.md: names={names}")
+    return out_path
+
+
+def _resolve_real_env_model(client: hibot.Client) -> V1Model:
+    """Mirror Go: prefer HIBOT_E2E_MODEL_ID, then models.get by ModelName, then list[0]."""
+    preset = _trim_env("HIBOT_E2E_MODEL_ID")
+    if preset:
+        print(f"using preset model id={preset} (HIBOT_E2E_MODEL_ID)")
+        return V1Model(id=preset)
+    try:
+        got = client.v1.models.get(
+            V1ModelGetParams(model_name=_V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO)
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"get default model by ModelName={_V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO!r} failed: {exc}; falling back to ListModels"
+        )
+        listing = client.v1.models.list()
+        if not listing.items:
+            pytest.fail(
+                "real-env workspace has no models; please pre-create one before running this test"
+            )
+        got = listing.items[0]
+        print(
+            f"fallback model picked: id={got.id} name={got.name} modelName={got.model_name} type={got.type}"
+        )
+    else:
+        print(
+            f"matched model by ModelName: id={got.id} name={got.name} modelName={got.model_name}"
+        )
+    return got
+
+
+def test_real_env_resource_skill_loop(tmp_path):
+    """Mirrors Go TestRealEnvResourceSkillLoop — full closed loop with cleanup."""
+    client, _host, _workspace = _new_real_client()
+
+    # Step 1: pick a usable model.
+    model = _resolve_real_env_model(client)
+
+    # Step 2: upload Resource fixture.
+    resource_filename = _E2E_RESOURCE_FIXTURE.name
+    with open(_E2E_RESOURCE_FIXTURE, "rb") as f:
+        runbook_bytes = f.read()
+    resource_blob = client.v1.uploads.upload_blob(
+        V1UploadBlobParams(filename=resource_filename, content_type="text/markdown"),
+        runbook_bytes,
+    )
+    if not resource_blob.blob_id:
+        pytest.fail(f"upload {resource_filename}: empty BlobID")
+    resource = client.v1.resources.create(
+        V1ResourceNewParams(
+            name=f"e2e-runbook-{time.time_ns()}",
+            type="document_collection",
+            blob_id=resource_blob.blob_id,
+        )
+    )
+    print(f"created resource: id={resource.id} name={resource.name}")
+
+    keep_agent = bool(_trim_env("HIBOT_E2E_KEEP_AGENT"))
+    cleanup_records: list[tuple[str, callable]] = []
+
+    def _cleanup():
+        if keep_agent:
+            return
+        for label, fn in reversed(cleanup_records):
+            try:
+                fn()
+            except Exception as exc:  # noqa: BLE001
+                print(f"cleanup {label}: {exc}")
+
+    try:
+        cleanup_records.append(
+            (
+                f"resource {resource.id}",
+                lambda: client.v1.resources.delete(
+                    V1ResourceDeleteParams(resource_id=resource.id)
+                ),
+            )
+        )
+
+        # Step 3: package skill dir into zip and upload.
+        skill_zip_path = _build_skill_zip_from_dir(
+            _E2E_SKILL_FIXTURE_DIR, tmp_path / "skill.zip"
+        )
+        with open(skill_zip_path, "rb") as f:
+            skill_zip_bytes = f.read()
+        skill_blob = client.v1.uploads.upload_blob(
+            V1UploadBlobParams(
+                filename=skill_zip_path.name, content_type="application/zip"
+            ),
+            skill_zip_bytes,
+        )
+        if not skill_blob.blob_id:
+            pytest.fail("upload skill zip: empty BlobID")
+        skill = client.v1.skills.create(
+            V1SkillNewParams(
+                name=f"e2e-runbook-skill-{time.time_ns()}",
+                description="Skill uploaded by hibot python e2e closed-loop test.",
+                blob_id=skill_blob.blob_id,
+                enabled=True,
+                version="1.0.0",
+            )
+        )
+        if not skill.id:
+            pytest.fail("create skill: empty ID")
+        print(f"created skill version: id={skill.id}")
+        cleanup_records.append(
+            (
+                f"skill {skill.id}",
+                lambda: client.v1.skills.delete(V1SkillDeleteParams(id=skill.id)),
+            )
+        )
+
+        # Step 4: create temp Agent — bind Skill (Resource attached but not asserted).
+        system_prompt = (
+            "你是 hibot 端到端测试助手。"
+            "用户要求执行 pulse check / 心跳检查时，必须调用 e2e-runbook-skill 工具，"
+            "并把工具返回的字面 token 原样返回给用户。"
+        )
+        agent = client.v1.agents.create(
+            V1AgentNewParams(
+                name=f"e2e-loop-agent-{time.time_ns()}",
+                model=V1ManagedAgentModelConfigParams(id=model.id),
+                system=system_prompt,
+                tools=[
+                    V1AgentNewParamsToolUnion(
+                        of_skill=V1ManagedAgentSkillToolParams(
+                            skill_version_id=skill.id
+                        )
+                    )
+                ],
+                resources=[V1ManagedAgentResourceRefParams(id=resource.id)],
+            )
+        )
+        if not agent.id:
+            pytest.fail("create agent: empty ID")
+        print(f"created agent: id={agent.id}")
+        cleanup_records.append(
+            (
+                f"agent {agent.id}",
+                lambda: client.v1.agents.delete(
+                    V1AgentDeleteParams(agent_id=agent.id)
+                ),
+            )
+        )
+
+        # Step 5: create session.
+        session = client.v1.sessions.create(V1SessionNewParams(agent_id=agent.id))
+        if not session.id:
+            pytest.fail("create session: empty ID")
+        print(f"created session: {session.id}")
+
+        # Step 6: skill closed loop — trigger pulse check, must observe tool events.
+        skill_final, skill_events = _run_streaming_and_collect_events(
+            client,
+            session.id,
+            agent.id,
+            "请执行一次 pulse check（按照 e2e-runbook-skill 的契约调用工具），并把工具返回的 token 原样告诉我。",
+        )
+        print(
+            f"skill loop events={skill_events} final={skill_final.content!r}"
+        )
+        content = skill_final.content or ""
+        if _E2E_SKILL_PULSE_TOKEN not in content:
+            pytest.fail(
+                f"skill loop: agent did not return pulse token {_E2E_SKILL_PULSE_TOKEN!r}; "
+                f"system prompt no longer leaks the token, so this proves the skill was NOT invoked. "
+                f"got={content!r}"
+            )
+        if not any(
+            ev in ("tool_start", "tool_complete") for ev in skill_events
+        ):
+            pytest.fail(
+                "skill loop: no tool_start/tool_complete event observed on SSE stream; "
+                "the model likely answered without actually invoking e2e-runbook-skill. "
+                f"events={skill_events}"
+            )
+        print(
+            f"skill loop ok: pulse token {_E2E_SKILL_PULSE_TOKEN!r} returned via real skill invocation (events={skill_events})"
+        )
+    finally:
+        _cleanup()

--- a/libs/hibot/tests/test_response.py
+++ b/libs/hibot/tests/test_response.py
@@ -1,0 +1,51 @@
+"""Tests for the TOP envelope decoder."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from hibot._response import APIError, decode_top
+
+
+def test_decode_top_returns_result():
+    body = json.dumps(
+        {
+            "ResponseMetadata": {"RequestId": "req-1"},
+            "Result": {"ID": "agent-1"},
+        }
+    ).encode("utf-8")
+    result = decode_top(200, body)
+    assert result == {"ID": "agent-1"}
+
+
+def test_decode_top_returns_none_for_missing_result():
+    body = json.dumps({"ResponseMetadata": {"RequestId": "req-2"}}).encode("utf-8")
+    assert decode_top(200, body) is None
+
+
+def test_decode_top_raises_on_top_error_field():
+    body = json.dumps(
+        {
+            "ResponseMetadata": {
+                "RequestId": "req-3",
+                "Error": {"Code": "InvalidParameter", "Message": "bad input"},
+            }
+        }
+    ).encode("utf-8")
+    with pytest.raises(APIError) as excinfo:
+        decode_top(200, body)
+    assert excinfo.value.code == "InvalidParameter"
+    assert excinfo.value.message == "bad input"
+    assert excinfo.value.request_id == "req-3"
+
+
+def test_decode_top_raises_on_http_error_status():
+    body = b"Internal Server Error"
+    with pytest.raises(APIError) as excinfo:
+        decode_top(500, body)
+    assert excinfo.value.status_code == 500
+
+
+def test_decode_top_handles_empty_body_with_2xx():
+    assert decode_top(200, b"") is None

--- a/libs/hibot/tests/test_sessions.py
+++ b/libs/hibot/tests/test_sessions.py
@@ -1,0 +1,169 @@
+"""Tests for SessionsService — peer injection + session->agent map + chat()."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+from hibot import (
+    V1SessionChatParams,
+    V1SessionDeleteParams,
+    V1SessionNewParams,
+    V1SessionPeerParams,
+)
+
+
+def _action(req: httpx.Request) -> str:
+    return parse_qs(urlsplit(str(req.url)).query).get("Action", [""])[0]
+
+
+def _version(req: httpx.Request) -> str:
+    return parse_qs(urlsplit(str(req.url)).query).get("Version", [""])[0]
+
+
+def test_create_session_injects_default_peer(client_factory, make_handler, ok_envelope):
+    handler = make_handler([ok_envelope({"ID": "s-1"})])
+    client = client_factory(handler)
+    session = client.v1.sessions.create(V1SessionNewParams(agent_id="agent-1"))
+    assert session.id == "s-1"
+    assert session.agent_id == "agent-1"
+
+    req = handler.calls[0]
+    assert _action(req) == "CreateSession"
+    body = json.loads(req.content)
+    assert body["AgentID"] == "agent-1"
+    assert body["WorkspaceID"] == "ws-1"
+    assert body["Payload"] == {
+        "Channel": "webchat",
+        "PeerKind": "system",
+        "PeerID": "agent-1",
+    }
+
+
+def test_create_session_with_explicit_peer_overrides_kind_and_id(
+    client_factory, make_handler, ok_envelope
+):
+    handler = make_handler([ok_envelope({"ID": "s-1"})])
+    client = client_factory(handler)
+    client.v1.sessions.create(
+        V1SessionNewParams(
+            agent_id="agent-1",
+            peer=V1SessionPeerParams(peer_kind="user", peer_id="u-77"),
+        )
+    )
+    body = json.loads(handler.calls[0].content)
+    assert body["Payload"] == {
+        "Channel": "webchat",
+        "PeerKind": "user",
+        "PeerID": "u-77",
+    }
+
+
+def test_create_session_with_im_channel_passes_through(
+    client_factory, make_handler, ok_envelope
+):
+    handler = make_handler([ok_envelope({"ID": "s-1"})])
+    client = client_factory(handler)
+    client.v1.sessions.create(
+        V1SessionNewParams(
+            agent_id="agent-1",
+            peer=V1SessionPeerParams(
+                channel="feishu", peer_kind="user", peer_id="ou_xxx"
+            ),
+        )
+    )
+    body = json.loads(handler.calls[0].content)
+    assert body["Payload"] == {
+        "Channel": "feishu",
+        "PeerKind": "user",
+        "PeerID": "ou_xxx",
+    }
+
+
+def test_chat_uses_remembered_agent_id_and_routes_to_gateway(
+    client_factory, make_handler, ok_envelope, sse
+):
+    sse_body = (
+        b'event: message_delta\n'
+        b'data: {"text":"hel"}\n\n'
+        b'event: message_delta\n'
+        b'data: {"text":"lo"}\n\n'
+        b'event: run_completed\n'
+        b'data: {"message":{"ID":"m-9","Role":"assistant","Content":"hello"}}\n\n'
+    )
+    create_reply = ok_envelope({"ID": "s-1"})
+    chat_reply = sse(sse_body)
+    handler = make_handler([create_reply, chat_reply])
+    client = client_factory(handler)
+
+    session = client.v1.sessions.create(V1SessionNewParams(agent_id="agent-1"))
+    msg = client.v1.sessions.chat(session.id, V1SessionChatParams(input="hi"))
+    assert msg.id == "m-9"
+    assert msg.content == "hello"
+
+    chat_req = handler.calls[1]
+    assert _action(chat_req) == "Chat"
+    assert _version(chat_req) == "2026-05-11"
+    body = json.loads(chat_req.content)
+    # AgentID resolved from internal map (was not provided in params)
+    assert body["AgentID"] == "agent-1"
+    assert body["SessionID"] == "s-1"
+    assert body["Content"] == "hi"
+    assert body["WorkspaceID"] == "ws-1"
+
+
+def test_chat_streaming_yields_events_in_order(
+    client_factory, make_handler, ok_envelope, sse
+):
+    sse_body = (
+        b'event: message_delta\n'
+        b'data: {"text":"a"}\n\n'
+        b'event: message_delta\n'
+        b'data: {"text":"b"}\n\n'
+        b'event: run_completed\n'
+        b'data: {"message":{"ID":"m-1","Content":"ab"}}\n\n'
+    )
+    handler = make_handler(
+        [
+            ok_envelope({"ID": "s-1"}),
+            sse(sse_body),
+        ]
+    )
+    client = client_factory(handler)
+    client.v1.sessions.create(V1SessionNewParams(agent_id="agent-1"))
+
+    events = []
+    with client.v1.sessions.chat_streaming(
+        "s-1", V1SessionChatParams(input="ping")
+    ) as stream:
+        for evt in stream:
+            events.append((evt.type, evt.delta.text))
+        final = stream.final_message()
+
+    assert events == [("delta", "a"), ("delta", "b"), ("completed", "")]
+    assert final.id == "m-1"
+
+
+def test_chat_streaming_propagates_http_error(client_factory, make_handler, ok_envelope, sse):
+    handler = make_handler(
+        [
+            ok_envelope({"ID": "s-1"}),
+            sse(b"boom", status=500),
+        ]
+    )
+    client = client_factory(handler)
+    client.v1.sessions.create(V1SessionNewParams(agent_id="agent-1"))
+    with client.v1.sessions.chat_streaming(
+        "s-1", V1SessionChatParams(input="x")
+    ) as stream:
+        assert stream.err is not None
+        assert getattr(stream.err, "status_code", None) == 500
+
+
+def test_delete_session_requires_id(client_factory, make_handler):
+    handler = make_handler([])
+    client = client_factory(handler)
+    with pytest.raises(ValueError):
+        client.v1.sessions.delete(V1SessionDeleteParams(session_id=""))

--- a/libs/hibot/tests/test_signer.py
+++ b/libs/hibot/tests/test_signer.py
@@ -1,0 +1,77 @@
+"""Tests for VOLC v4 signing (deterministic vector)."""
+
+from __future__ import annotations
+
+import datetime as _dt
+
+from hibot._signer import ALGORITHM, sign_request
+
+
+def test_sign_request_produces_v4_authorization_header():
+    headers = sign_request(
+        method="POST",
+        url="https://open.volcengineapi.com/?Action=GetAgent&Version=2026-04-23",
+        headers={"Content-Type": "application/json"},
+        body=b'{"AgentID":"a-1"}',
+        access_key="AKLTexample",
+        secret_key="example-secret",
+        region="cn-north-1",
+        service="hibot-server",
+        now=_dt.datetime(2026, 5, 24, 1, 2, 3, tzinfo=_dt.timezone.utc),
+    )
+
+    assert headers["X-Date"] == "20260524T010203Z"
+    assert "X-Content-Sha256" in headers
+    assert headers["Host"] == "open.volcengineapi.com"
+    auth = headers["Authorization"]
+    assert auth.startswith(ALGORITHM + " ")
+    assert "Credential=AKLTexample/20260524/cn-north-1/hibot-server/request" in auth
+    assert "SignedHeaders=content-type;host;x-content-sha256;x-date" in auth
+    # Signature must be deterministic given the fixed `now`.
+    assert "Signature=" in auth
+    sig = auth.split("Signature=", 1)[1]
+    assert len(sig) == 64
+    assert all(ch in "0123456789abcdef" for ch in sig)
+
+
+def test_sign_request_changes_signature_on_body_diff():
+    common = dict(
+        method="POST",
+        url="https://open.volcengineapi.com/?Action=Foo&Version=2026-04-23",
+        headers={"Content-Type": "application/json"},
+        access_key="AK",
+        secret_key="SK",
+        region="cn-north-1",
+        service="hibot-server",
+        now=_dt.datetime(2026, 1, 2, 3, 4, 5, tzinfo=_dt.timezone.utc),
+    )
+    h1 = sign_request(body=b'{"x":1}', **common)
+    h2 = sign_request(body=b'{"x":2}', **common)
+    assert h1["Authorization"] != h2["Authorization"]
+    assert h1["X-Content-Sha256"] != h2["X-Content-Sha256"]
+
+
+def test_sign_request_canonical_query_sort_is_stable():
+    h1 = sign_request(
+        method="POST",
+        url="https://example.com/?B=2&A=1",
+        headers={"Content-Type": "application/json"},
+        body=b"",
+        access_key="AK",
+        secret_key="SK",
+        region="cn-north-1",
+        service="svc",
+        now=_dt.datetime(2026, 1, 1, tzinfo=_dt.timezone.utc),
+    )
+    h2 = sign_request(
+        method="POST",
+        url="https://example.com/?A=1&B=2",
+        headers={"Content-Type": "application/json"},
+        body=b"",
+        access_key="AK",
+        secret_key="SK",
+        region="cn-north-1",
+        service="svc",
+        now=_dt.datetime(2026, 1, 1, tzinfo=_dt.timezone.utc),
+    )
+    assert h1["Authorization"] == h2["Authorization"]

--- a/libs/hibot/tests/test_sse.py
+++ b/libs/hibot/tests/test_sse.py
@@ -1,0 +1,105 @@
+"""Tests for SSE decoder + chat event normalization."""
+
+from __future__ import annotations
+
+import json
+
+from hibot._sse import ByteStreamDecoder, iter_frames
+from hibot.v1.stream import (
+    decode_chat_event,
+    normalize_chat_event_name,
+)
+from hibot.v1.types import (
+    V1_SESSION_CHAT_EVENT_COMPLETED,
+    V1_SESSION_CHAT_EVENT_DELTA,
+    V1_SESSION_CHAT_EVENT_FAILED,
+    V1_SESSION_CHAT_EVENT_TOOL_COMPLETE,
+    V1_SESSION_CHAT_EVENT_TOOL_START,
+)
+
+
+def test_iter_frames_decodes_basic():
+    payload = (
+        ":heartbeat\n"
+        "event: message_delta\n"
+        'data: {"text":"hi"}\n'
+        "\n"
+        "event: run_completed\n"
+        'data: {"message":{"ID":"m-1"}}\n'
+        "\n"
+    )
+    frames = list(iter_frames(payload.split("\n")))
+    assert len(frames) == 2
+    assert frames[0].event == "message_delta"
+    assert json.loads(frames[0].data)["text"] == "hi"
+    assert frames[1].event == "run_completed"
+
+
+def test_byte_stream_decoder_incremental():
+    decoder = ByteStreamDecoder()
+    decoder.feed(b"event: message_delta\n")
+    decoder.feed(b'data: {"text":')
+    decoder.feed(b'"abc"}\n\n')
+    frames = decoder.pop_frames()
+    assert len(frames) == 1
+    assert frames[0].event == "message_delta"
+    assert json.loads(frames[0].data) == {"text": "abc"}
+
+
+def test_normalize_chat_event_name_legacy_aliases():
+    assert normalize_chat_event_name("message.chunk") == V1_SESSION_CHAT_EVENT_DELTA
+    assert normalize_chat_event_name("message_delta") == V1_SESSION_CHAT_EVENT_DELTA
+    assert normalize_chat_event_name("message_chunk") == V1_SESSION_CHAT_EVENT_DELTA
+    assert (
+        normalize_chat_event_name("message.completed")
+        == V1_SESSION_CHAT_EVENT_COMPLETED
+    )
+    assert (
+        normalize_chat_event_name("run_completed") == V1_SESSION_CHAT_EVENT_COMPLETED
+    )
+    assert normalize_chat_event_name("run_failed") == V1_SESSION_CHAT_EVENT_FAILED
+    assert normalize_chat_event_name("tool_started") == V1_SESSION_CHAT_EVENT_TOOL_START
+    assert (
+        normalize_chat_event_name("tool_completed") == V1_SESSION_CHAT_EVENT_TOOL_COMPLETE
+    )
+    # passthrough
+    assert normalize_chat_event_name("delta") == V1_SESSION_CHAT_EVENT_DELTA
+    assert normalize_chat_event_name("approval_request") == "approval_request"
+
+
+def test_decode_chat_event_extracts_delta_text():
+    event = decode_chat_event("message_delta", json.dumps({"delta": {"text": "hello"}}))
+    assert event.type == V1_SESSION_CHAT_EVENT_DELTA
+    assert event.delta.text == "hello"
+
+
+def test_decode_chat_event_extracts_completed_message():
+    data = json.dumps(
+        {
+            "message": {"ID": "m-1", "Role": "assistant", "Content": "ok"},
+            "request_id": "req-x",
+        }
+    )
+    event = decode_chat_event("run_completed", data)
+    assert event.type == V1_SESSION_CHAT_EVENT_COMPLETED
+    assert event.request_id == "req-x"
+    assert event.message is not None
+    assert event.message.id == "m-1"
+    assert event.message.content == "ok"
+
+
+def test_decode_chat_event_extracts_failed_error():
+    data = json.dumps({"error": {"code": "Boom", "message": "explode"}})
+    event = decode_chat_event("run_failed", data)
+    assert event.type == V1_SESSION_CHAT_EVENT_FAILED
+    assert event.error.code == "Boom"
+    assert event.error.message == "explode"
+
+
+def test_decode_chat_event_falls_back_to_top_level_message_id():
+    data = json.dumps({"message_id": "m-2", "content": "fallback"})
+    event = decode_chat_event("completed", data)
+    assert event.type == V1_SESSION_CHAT_EVENT_COMPLETED
+    assert event.message is not None
+    assert event.message.id == "m-2"
+    assert event.message.content == "fallback"

--- a/libs/hibot/tests/test_stream.py
+++ b/libs/hibot/tests/test_stream.py
@@ -1,0 +1,86 @@
+"""Tests for the V1SessionChatStream wrapper (accumulate / final_message)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from hibot.v1.stream import V1SessionChatStream
+
+
+class _FakeResp:
+    """A minimal stand-in for the httpx-backed stream response."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self.closed = False
+
+    def iter_bytes(self):
+        for c in self._chunks:
+            yield c
+
+    def close(self):
+        self.closed = True
+
+
+def _sse(*frames: tuple[str, dict]) -> list[bytes]:
+    out = []
+    for event, data in frames:
+        block = f"event: {event}\ndata: {json.dumps(data)}\n\n"
+        out.append(block.encode("utf-8"))
+    return out
+
+
+def test_stream_accumulate_concatenates_deltas():
+    chunks = _sse(
+        ("message_delta", {"text": "Hel"}),
+        ("message_delta", {"text": "lo "}),
+        ("message_delta", {"text": "world"}),
+        ("run_completed", {"message": {"ID": "m-1", "Content": "Hello world"}}),
+    )
+    stream = V1SessionChatStream(resp=_FakeResp(chunks))
+    msg = stream.accumulate()
+    assert msg.id == "m-1"
+    assert msg.content == "Hello world"
+
+
+def test_stream_accumulate_falls_back_to_buffered_text_when_no_message():
+    chunks = _sse(
+        ("message_delta", {"text": "abc"}),
+        ("run_completed", {}),
+    )
+    stream = V1SessionChatStream(resp=_FakeResp(chunks))
+    msg = stream.accumulate()
+    assert msg.role == "assistant"
+    assert msg.content == "abc"
+
+
+def test_stream_accumulate_raises_on_failed_event():
+    chunks = _sse(
+        ("message_delta", {"text": "hi"}),
+        ("run_failed", {"error": {"code": "X", "message": "boom"}}),
+    )
+    stream = V1SessionChatStream(resp=_FakeResp(chunks))
+    with pytest.raises(Exception) as exc:
+        stream.accumulate()
+    assert "boom" in str(exc.value)
+
+
+def test_stream_iterator_yields_typed_events():
+    chunks = _sse(
+        ("message_delta", {"text": "x"}),
+        ("run_completed", {"message": {"ID": "m-2"}}),
+    )
+    stream = V1SessionChatStream(resp=_FakeResp(chunks))
+    events = list(stream)
+    types = [e.type for e in events]
+    assert types == ["delta", "completed"]
+    assert stream.final_message().id == "m-2"
+
+
+def test_stream_init_with_error_short_circuits():
+    err = ValueError("boom")
+    stream = V1SessionChatStream(error=err)
+    assert stream.err is err
+    assert stream.next() is False
+    assert list(stream) == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,10 @@ hiagent-api = { workspace = true }
 hiagent-components = { workspace = true }
 hiagent-eva = { workspace = true }
 hiagent-observe = { workspace = true }
+hibot = { workspace = true }
 
 [tool.uv.workspace]
-members = ["libs/api", "libs/components", "libs/eva", "libs/observe"]
+members = ["libs/api", "libs/components", "libs/eva", "libs/observe", "libs/hibot"]
 
 [dependency-groups]
 dev = [
@@ -25,6 +26,7 @@ dev = [
     "hiagent-api",
     "hiagent-eva",
     "hiagent-observe",
+    "hibot",
     "mcp>=1.23.0",
     "langchain-core>=0.3.84",
     "chainlit>=2.9.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -15,6 +15,7 @@ members = [
     "hiagent-eva",
     "hiagent-observe",
     "hiagent-sdk-monorepo",
+    "hibot",
 ]
 
 [[package]]
@@ -1104,7 +1105,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.4.0" }]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "hiagent-observe"
@@ -1151,6 +1152,7 @@ dev = [
     { name = "hiagent-components" },
     { name = "hiagent-eva" },
     { name = "hiagent-observe" },
+    { name = "hibot" },
     { name = "langchain" },
     { name = "langchain-core" },
     { name = "langchain-ollama" },
@@ -1177,6 +1179,7 @@ dev = [
     { name = "hiagent-components", editable = "libs/components" },
     { name = "hiagent-eva", editable = "libs/eva" },
     { name = "hiagent-observe", editable = "libs/observe" },
+    { name = "hibot", editable = "libs/hibot" },
     { name = "langchain", specifier = ">=0.3.25" },
     { name = "langchain-core", specifier = ">=0.3.84" },
     { name = "langchain-ollama", specifier = ">=0.3.3" },
@@ -1193,6 +1196,26 @@ dev = [
     { name = "starlette", specifier = ">=0.49.1" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
+
+[[package]]
+name = "hibot"
+version = "1.0.0"
+source = { editable = "libs/hibot" }
+dependencies = [
+    { name = "httpx" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "httpcore"
@@ -2784,7 +2807,23 @@ wheels = [
 name = "pycryptodome"
 version = "3.19.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/3a/5bca2cb1648b171afd6b7d29a11c6bca8b305bb75b7e2d78a0f5c61ff95e/pycryptodome-3.9.9.tar.gz", hash = "sha256:910e202a557e1131b1c1b3f17a63914d57aac55cf9fb9b51644962841c3995c4", size = 15488528, upload-time = "2020-11-03T13:15:26.723Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/38/42a8855ff1bf568c61ca6557e2203f318fb7afeadaf2eb8ecfdbde107151/pycryptodome-3.19.1.tar.gz", hash = "sha256:8ae0dd1bcfada451c35f9e29a3e5db385caabc190f98e4a80ad02a61098fb776", size = 4782144, upload-time = "2023-12-28T06:52:40.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/ef/4931bc30674f0de0ca0e827b58c8b0c17313a8eae2754976c610b866118b/pycryptodome-3.19.1-cp35-abi3-macosx_10_9_universal2.whl", hash = "sha256:67939a3adbe637281c611596e44500ff309d547e932c449337649921b17b6297", size = 2417027, upload-time = "2023-12-28T06:51:50.138Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e6/238c53267fd8d223029c0a0d3730cb1b6594d60f62e40c4184703dc490b1/pycryptodome-3.19.1-cp35-abi3-macosx_10_9_x86_64.whl", hash = "sha256:11ddf6c9b52116b62223b6a9f4741bc4f62bb265392a4463282f7f34bb287180", size = 1579728, upload-time = "2023-12-28T06:51:52.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/87/7181c42c8d5ba89822a4b824830506d0aeec02959bb893614767e3279846/pycryptodome-3.19.1-cp35-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3e6f89480616781d2a7f981472d0cdb09b9da9e8196f43c1234eff45c915766", size = 2051440, upload-time = "2023-12-28T06:51:55.751Z" },
+    { url = "https://files.pythonhosted.org/packages/34/dd/332c4c0055527d17dac317ed9f9c864fc047b627d82f4b9a56c110afc6fc/pycryptodome-3.19.1-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27e1efcb68993b7ce5d1d047a46a601d41281bba9f1971e6be4aa27c69ab8065", size = 2125379, upload-time = "2023-12-28T06:51:58.567Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9e/320b885ea336c218ff54ec2b276cd70ba6904e4f5a14a771ed39a2c47d59/pycryptodome-3.19.1-cp35-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c6273ca5a03b672e504995529b8bae56da0ebb691d8ef141c4aa68f60765700", size = 2153951, upload-time = "2023-12-28T06:52:01.699Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/54/8ae0c43d1257b41bc9d3277c3f875174fd8ad86b9567f0b8609b99c938ee/pycryptodome-3.19.1-cp35-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:b0bfe61506795877ff974f994397f0c862d037f6f1c0bfc3572195fc00833b96", size = 2044041, upload-time = "2023-12-28T06:52:03.737Z" },
+    { url = "https://files.pythonhosted.org/packages/45/93/f8450a92cc38541c3ba1f4cb4e267e15ae6d6678ca617476d52c3a3764d4/pycryptodome-3.19.1-cp35-abi3-musllinux_1_1_i686.whl", hash = "sha256:f34976c5c8eb79e14c7d970fb097482835be8d410a4220f86260695ede4c3e17", size = 2182446, upload-time = "2023-12-28T06:52:05.588Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ed6e429fb0792ce368f66e83246264dd3a7a045b0b1e63043ed22a063ce5/pycryptodome-3.19.1-cp35-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:7c9e222d0976f68d0cf6409cfea896676ddc1d98485d601e9508f90f60e2b0a2", size = 2144914, upload-time = "2023-12-28T06:52:07.44Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/23/b064bd4cfbf2cc5f25afcde0e7c880df5b20798172793137ba4b62d82e72/pycryptodome-3.19.1-cp35-abi3-win32.whl", hash = "sha256:4805e053571140cb37cf153b5c72cd324bb1e3e837cbe590a19f69b6cf85fd03", size = 1713105, upload-time = "2023-12-28T06:52:09.585Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/e0/ded1968a5257ab34216a0f8db7433897a2337d59e6d03be113713b346ea2/pycryptodome-3.19.1-cp35-abi3-win_amd64.whl", hash = "sha256:a470237ee71a1efd63f9becebc0ad84b88ec28e6784a2047684b693f458f41b7", size = 1749222, upload-time = "2023-12-28T06:52:11.534Z" },
+    { url = "https://files.pythonhosted.org/packages/05/56/00a9147d1d439e1ff1c90e23917b1d82c6b4ee91c40ff5af7113cd312c78/pycryptodome-3.19.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:37e531bf896b70fe302f003d3be5a0a8697737a8d177967da7e23eff60d6483c", size = 1555298, upload-time = "2023-12-28T06:52:18.183Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cb/7e60730946756f9fef0e0a1d06c9687522293aee40bce2884bb6534bc0f6/pycryptodome-3.19.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd4e95b0eb4b28251c825fe7aa941fe077f993e5ca9b855665935b86fbb1cc08", size = 1596086, upload-time = "2023-12-28T06:52:21.099Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c5/a8db81dab2b5ae2e0e2cbfef4fe8a4c07a6b04ba510105c9f3b0720ddb3b/pycryptodome-3.19.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c22c80246c3c880c6950d2a8addf156cee74ec0dc5757d01e8e7067a3c7da015", size = 1626967, upload-time = "2023-12-28T06:52:23.921Z" },
+    { url = "https://files.pythonhosted.org/packages/34/88/dd3fcdc1cf3f71341264745c6ab90ebd9f3d8829511cf6c0ab960177801a/pycryptodome-3.19.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e70f5c839c7798743a948efa2a65d1fe96bb397fe6d7f2bde93d869fe4f0ad69", size = 1730821, upload-time = "2023-12-28T06:52:26.79Z" },
+]
 
 [[package]]
 name = "pydantic"
@@ -2941,9 +2980,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -2971,9 +3010,9 @@ wheels = [
 name = "python-multipart"
 version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/45/e23b5dc14ddb9918ae4a625379506b17b6f8fc56ca1d82db62462f59aea6/python_multipart-0.0.24.tar.gz", hash = "sha256:9574c97e1c026e00bc30340ef7c7d76739512ab4dfd428fec8c330fa6a5cc3c8", size = 37695, upload-time = "2026-04-05T20:49:13.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/73/89930efabd4da63cea44a3f438aeb753d600123570e6d6264e763617a9ce/python_multipart-0.0.24-py3-none-any.whl", hash = "sha256:9b110a98db707df01a53c194f0af075e736a770dc5058089650d70b4a182f950", size = 24420, upload-time = "2026-04-05T20:49:12.555Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景 

## 变更点
- `libs/hibot/hibot/`：新增 `hibot` import 包，包含 Hibot 客户端、配置、TOP v4 签名、SSE、V1 资源客户端。
- `libs/hibot/tests/`：新增离线单测与真实 E2E 测试。
- `libs/hibot/testdata/`：新增真实 E2E Resource / Skill fixture，避免依赖其他仓路径。
- `libs/hibot/pyproject.toml`：新增 PyPI 包配置，包名 `hibot`。
- `pyproject.toml`、`Makefile`、`uv.lock`：将 `libs/hibot` 纳入 uv workspace 与 build 入口。

## 破坏式变更
否。新增 workspace member，不修改官方既有包的 import 路径或 API。

## 验证方式
- 单测：`PYTHONPATH=. pytest -q` in `libs/hibot` 通过。
- 真实 E2E：`PYTHONPATH=. pytest -q tests/test_real_env.py` 通过。
- 合规修复：已移除迁移中残留的内部词汇注释。

## 合规自检
未发现真实凭据、内网域名、员工邮箱或本机绝对路径写入文件。
