### PR TITLE
feat(python): CreateSession 自动生成并透传 ConversationID

### DIFF
--- a/libs/hibot/hibot/v1/sessions.py
+++ b/libs/hibot/hibot/v1/sessions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import secrets
 import threading
 
 from .._request import Action
@@ -28,6 +29,16 @@ from .types import (
 )
 
 
+def _generate_conversation_id() -> str:
+    """生成符合 ``^[A-Za-z0-9_-]{1,64}$`` 的 ConversationID。
+
+    使用 16 字节随机数转 32 位 hex，长度与字符集均严格满足，且各端 SDK 共用
+    同一种生成策略。仅在 webchat 渠道下注入。
+    """
+
+    return secrets.token_hex(16)
+
+
 class SessionsService:
     def __init__(self, v1) -> None:
         self._v1 = v1
@@ -48,8 +59,7 @@ class SessionsService:
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         # Peer 仅在显式指定 IM 渠道或按 user 隔离会话时才需要传入；webchat
-        # 主流程下 SDK 注入 webchat / system / agent_id 作为默认值，确保
-        # 服务端 SessionKey 唯一确定。
+        # 主流程下 SDK 注入 webchat / system / agent_id 作为默认值。
         payload = {
             "Channel": "webchat",
             "PeerKind": "system",
@@ -62,6 +72,12 @@ class SessionsService:
                 payload["PeerKind"] = params.peer.peer_kind
             if params.peer.peer_id:
                 payload["PeerID"] = params.peer.peer_id
+        # ConversationID 仅在 webchat 渠道由 SDK 自动生成并透传；其它渠道
+        # 留空，这里直接跳过以避免污染请求体。
+        if payload["Channel"] == "webchat":
+            cid = _generate_conversation_id()
+            if cid:
+                payload["ConversationID"] = cid
         body["Payload"] = payload
         result = self._action("CreateSession", body)
         session = from_dict(V1Session, result) or V1Session()

--- a/libs/hibot/tests/test_sessions.py
+++ b/libs/hibot/tests/test_sessions.py
@@ -35,11 +35,17 @@ def test_create_session_injects_default_peer(client_factory, make_handler, ok_en
     body = json.loads(req.content)
     assert body["AgentID"] == "agent-1"
     assert body["WorkspaceID"] == "ws-1"
-    assert body["Payload"] == {
-        "Channel": "webchat",
-        "PeerKind": "system",
-        "PeerID": "agent-1",
-    }
+    payload = body["Payload"]
+    # ConversationID 由 SDK 自动生成（仅 webchat 渠道）；逐字段断言其余 peer
+    # 默认值，避免与自动注入的 ConversationID 互相干扰。
+    assert payload["Channel"] == "webchat"
+    assert payload["PeerKind"] == "system"
+    assert payload["PeerID"] == "agent-1"
+    cid = payload["ConversationID"]
+    assert isinstance(cid, str) and 1 <= len(cid) <= 64
+    import re
+
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", cid)
 
 
 def test_create_session_with_explicit_peer_overrides_kind_and_id(
@@ -54,11 +60,12 @@ def test_create_session_with_explicit_peer_overrides_kind_and_id(
         )
     )
     body = json.loads(handler.calls[0].content)
-    assert body["Payload"] == {
-        "Channel": "webchat",
-        "PeerKind": "user",
-        "PeerID": "u-77",
-    }
+    payload = body["Payload"]
+    assert payload["Channel"] == "webchat"
+    assert payload["PeerKind"] == "user"
+    assert payload["PeerID"] == "u-77"
+    # webchat 渠道下仍会自动注入 ConversationID。
+    assert "ConversationID" in payload
 
 
 def test_create_session_with_im_channel_passes_through(
@@ -75,11 +82,26 @@ def test_create_session_with_im_channel_passes_through(
         )
     )
     body = json.loads(handler.calls[0].content)
+    # 非 webchat 渠道 SDK 不注入 ConversationID。
     assert body["Payload"] == {
         "Channel": "feishu",
         "PeerKind": "user",
         "PeerID": "ou_xxx",
     }
+
+
+def test_create_session_conversation_ids_are_unique(
+    client_factory, make_handler, ok_envelope
+):
+    handler = make_handler(
+        [ok_envelope({"ID": "s-1"}), ok_envelope({"ID": "s-2"})]
+    )
+    client = client_factory(handler)
+    client.v1.sessions.create(V1SessionNewParams(agent_id="agent-1"))
+    client.v1.sessions.create(V1SessionNewParams(agent_id="agent-1"))
+    cid1 = json.loads(handler.calls[0].content)["Payload"]["ConversationID"]
+    cid2 = json.loads(handler.calls[1].content)["Payload"]["ConversationID"]
+    assert cid1 != cid2
 
 
 def test_chat_uses_remembered_agent_id_and_routes_to_gateway(


### PR DESCRIPTION
## 背景 / 动机

webchat 渠道的 CreateSession 需要 `ConversationID` 字段才能在同一 Peer 下做多会话隔离；之前需要调用方自己造一个符合服务端正则 `^[A-Za-z0-9_-]{1,64}$` 的字符串，体验差且容易触发服务端 400。本次让 SDK 在内部自动生成并透传，调用方无感。

## 变更点

- 新增 `_generate_conversation_id`：基于 `secrets.token_hex(16)`，输出 32 位 hex，长度与字符集天然落在契约内
- `SessionsService.create` 在 `Channel == "webchat"` 时自动注入 `ConversationID`；IM 渠道保持不注入
- `tests/test_sessions.py` 更新现有断言并新增 `test_create_session_conversation_ids_are_unique`


## 破坏式变更

否。`V1SessionNewParams` 公共结构未变；新行为对既有调用透明。

## 验证方式

- 单测：`pytest tests/test_sessions.py -q` ✅

## 合规自检

未触发红线。注释只描述外部可观察契约，未暴露服务端内部实现细节。
