### PR TITLE
feat(python): 三项 SDK 变更对齐内部 hibot-sdk（chat Approve / Files / SecretValue）

### DIFF
--- a/libs/hibot/hibot/v1/mcps.py
+++ b/libs/hibot/hibot/v1/mcps.py
@@ -9,6 +9,7 @@ from .._version import SERVER_VERSION
 from ._helpers import from_dict, list_from_items
 from .types import (
     V1MCP,
+    V1MCPCredentialInputParams,
     V1MCPDeleteParams,
     V1MCPGetParams,
     V1MCPListParams,
@@ -18,6 +19,37 @@ from .types import (
     V1MCPTestConnectionResult,
     V1MCPUpdateParams,
 )
+
+
+def _credential_config_to_dict(cfg: V1MCPCredentialInputParams) -> dict:
+    body: dict = {}
+    if cfg.name:
+        body["Name"] = cfg.name
+    if cfg.description:
+        body["Description"] = cfg.description
+    if cfg.source:
+        body["Source"] = cfg.source
+    if cfg.provider_type:
+        body["ProviderType"] = cfg.provider_type
+    if cfg.config is not None:
+        body["Config"] = cfg.config
+    if cfg.secrets:
+        secrets_list = []
+        for s in cfg.secrets:
+            entry: dict = {}
+            if s.secret_id:
+                entry["SecretID"] = s.secret_id
+            if s.key_name:
+                entry["KeyName"] = s.key_name
+            if s.description:
+                entry["Description"] = s.description
+            if s.secret_type:
+                entry["SecretType"] = s.secret_type
+            if s.secret_value:
+                entry["SecretValue"] = s.secret_value
+            secrets_list.append(entry)
+        body["Secrets"] = secrets_list
+    return body
 
 
 class MCPsService:
@@ -48,8 +80,8 @@ class MCPsService:
             body["Args"] = list(params.args)
         if params.auth_type:
             body["AuthType"] = params.auth_type
-        if params.credential is not None:
-            body["Credential"] = {"Name": params.credential.name}
+        if params.credential_config is not None:
+            body["CredentialConfig"] = _credential_config_to_dict(params.credential_config)
         if params.tool_allowlist is not None:
             body["ToolAllowlist"] = list(params.tool_allowlist)
         if params.tool_denylist is not None:
@@ -117,6 +149,8 @@ class MCPsService:
             body["Args"] = list(params.args)
         if params.auth_type is not None:
             body["AuthType"] = params.auth_type
+        if params.credential_config is not None:
+            body["CredentialConfig"] = _credential_config_to_dict(params.credential_config)
         if params.tool_allowlist is not None:
             body["ToolAllowlist"] = list(params.tool_allowlist)
         if params.tool_denylist is not None:
@@ -155,8 +189,8 @@ class MCPsService:
             body["Args"] = list(params.args)
         if params.auth_type:
             body["AuthType"] = params.auth_type
-        if params.credential is not None:
-            body["Credential"] = {"Name": params.credential.name}
+        if params.credential_config is not None:
+            body["CredentialConfig"] = _credential_config_to_dict(params.credential_config)
         if params.timeout:
             body["Timeout"] = params.timeout
         if params.workspace_id:

--- a/libs/hibot/hibot/v1/sessions.py
+++ b/libs/hibot/hibot/v1/sessions.py
@@ -219,7 +219,8 @@ class SessionsService:
     # Chat --------------------------------------------------------------
 
     def chat(self, session_id: str, params: V1SessionChatParams) -> V1Message:
-        with self.chat_streaming(session_id, params) as stream:
+        # 非流式 Chat 自动 set-all 审批，避免单回合中断在审批环节。
+        with self._chat_streaming(session_id, params, auto_approve_all=True) as stream:
             for event in stream:
                 if event.type == V1_SESSION_CHAT_EVENT_FAILED:
                     msg = event.error.message or event.error.code or "unknown error"
@@ -229,6 +230,14 @@ class SessionsService:
             return stream.final_message()
 
     def chat_streaming(self, session_id: str, params: V1SessionChatParams) -> V1SessionChatStream:
+        return self._chat_streaming(session_id, params, auto_approve_all=False)
+
+    def _chat_streaming(
+        self,
+        session_id: str,
+        params: V1SessionChatParams,
+        auto_approve_all: bool,
+    ) -> V1SessionChatStream:
         if not session_id:
             return V1SessionChatStream(error=ValueError("hibot: session id is required"))
         agent_id = params.agent_id
@@ -239,10 +248,28 @@ class SessionsService:
             "AgentID": agent_id,
             "Content": params.input,
         }
+        if params.files:
+            files_payload = []
+            for f in params.files:
+                entry: dict = {}
+                if f.file_id:
+                    entry["FileID"] = f.file_id
+                if f.name:
+                    entry["Name"] = f.name
+                if f.content_type:
+                    entry["ContentType"] = f.content_type
+                if f.url:
+                    entry["URL"] = f.url
+                if f.blob_id:
+                    entry["BlobID"] = f.blob_id
+                files_payload.append(entry)
+            body["Files"] = files_payload
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         if params.client_message_id:
             body["ClientMessageID"] = params.client_message_id
+        if auto_approve_all:
+            body["Approve"] = "all"
         try:
             resp = self._v1.requester.stream_action(
                 Action(

--- a/libs/hibot/hibot/v1/skills.py
+++ b/libs/hibot/hibot/v1/skills.py
@@ -9,6 +9,7 @@ from .._version import SERVER_VERSION
 from ._helpers import from_dict, list_from_items
 from .types import (
     V1Skill,
+    V1SkillCredentialInputParams,
     V1SkillDeleteParams,
     V1SkillGetParams,
     V1SkillListParams,
@@ -18,6 +19,37 @@ from .types import (
     V1SkillVersion,
     V1SkillVersionListParams,
 )
+
+
+def _credential_config_to_dict(cfg: V1SkillCredentialInputParams) -> dict:
+    body: dict = {}
+    if cfg.name:
+        body["Name"] = cfg.name
+    if cfg.description:
+        body["Description"] = cfg.description
+    if cfg.source:
+        body["Source"] = cfg.source
+    if cfg.provider_type:
+        body["ProviderType"] = cfg.provider_type
+    if cfg.config is not None:
+        body["Config"] = cfg.config
+    if cfg.secrets:
+        secrets_list = []
+        for s in cfg.secrets:
+            entry: dict = {}
+            if s.secret_id:
+                entry["SecretID"] = s.secret_id
+            if s.key_name:
+                entry["KeyName"] = s.key_name
+            if s.description:
+                entry["Description"] = s.description
+            if s.secret_type:
+                entry["SecretType"] = s.secret_type
+            if s.secret_value:
+                entry["SecretValue"] = s.secret_value
+            secrets_list.append(entry)
+        body["Secrets"] = secrets_list
+    return body
 
 
 class SkillsService:
@@ -44,6 +76,8 @@ class SkillsService:
             body["Enabled"] = params.enabled
         if params.slug_id:
             body["SlugID"] = params.slug_id
+        if params.credential_config is not None:
+            body["CredentialConfig"] = _credential_config_to_dict(params.credential_config)
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         result = self._action("CreateSkill", body)
@@ -114,6 +148,8 @@ class SkillsService:
             body["NewVersion"] = params.new_version
         if params.slug_id is not None:
             body["SlugID"] = params.slug_id
+        if params.credential_config is not None:
+            body["CredentialConfig"] = _credential_config_to_dict(params.credential_config)
         self._action("UpdateSkill", body)
 
     def delete(self, params: V1SkillDeleteParams) -> None:

--- a/libs/hibot/hibot/v1/types.py
+++ b/libs/hibot/hibot/v1/types.py
@@ -291,6 +291,7 @@ class V1MessageFile:
     name: Optional[str] = field(default=None, metadata={"json": "Name"})
     content_type: Optional[str] = field(default=None, metadata={"json": "ContentType"})
     url: Optional[str] = field(default=None, metadata={"json": "URL"})
+    blob_id: Optional[str] = field(default=None, metadata={"json": "BlobID"})
 
 
 @dataclass
@@ -546,8 +547,32 @@ class V1DirectoryGetByNameParams:
 
 
 @dataclass
-class V1CredentialRefParams:
+class V1CredentialSecretInputParams:
+    secret_id: str = ""
+    key_name: str = ""
+    description: str = ""
+    secret_type: str = ""
+    secret_value: str = ""
+
+
+@dataclass
+class V1MCPCredentialInputParams:
     name: str = ""
+    description: str = ""
+    source: str = ""
+    provider_type: str = ""
+    config: Optional[Any] = None
+    secrets: Optional[List[V1CredentialSecretInputParams]] = None
+
+
+@dataclass
+class V1SkillCredentialInputParams:
+    name: str = ""
+    description: str = ""
+    source: str = ""
+    provider_type: str = ""
+    config: Optional[Any] = None
+    secrets: Optional[List[V1CredentialSecretInputParams]] = None
 
 
 @dataclass
@@ -561,7 +586,7 @@ class V1MCPNewParams:
     command: str = ""
     args: Optional[List[str]] = None
     auth_type: str = ""
-    credential: Optional[V1CredentialRefParams] = None
+    credential_config: Optional[V1MCPCredentialInputParams] = None
     tool_allowlist: Optional[List[str]] = None
     tool_denylist: Optional[List[str]] = None
     tool_prefix: str = ""
@@ -597,6 +622,7 @@ class V1MCPUpdateParams:
     command: Optional[str] = None
     args: Optional[List[str]] = None
     auth_type: Optional[str] = None
+    credential_config: Optional[V1MCPCredentialInputParams] = None
     tool_allowlist: Optional[List[str]] = None
     tool_denylist: Optional[List[str]] = None
     tool_prefix: Optional[str] = None
@@ -621,7 +647,7 @@ class V1MCPTestConnectionParams:
     command: str = ""
     args: Optional[List[str]] = None
     auth_type: str = ""
-    credential: Optional[V1CredentialRefParams] = None
+    credential_config: Optional[V1MCPCredentialInputParams] = None
     timeout: int = 0
     workspace_id: str = ""
 
@@ -643,6 +669,7 @@ class V1SkillNewParams:
     enabled: Optional[bool] = None
     version: str = ""
     slug_id: str = ""
+    credential_config: Optional[V1SkillCredentialInputParams] = None
     workspace_id: str = ""
 
 
@@ -675,6 +702,7 @@ class V1SkillUpdateParams:
     enabled: Optional[bool] = None
     new_version: Optional[str] = None
     slug_id: Optional[str] = None
+    credential_config: Optional[V1SkillCredentialInputParams] = None
     workspace_id: str = ""
 
 
@@ -802,6 +830,7 @@ class V1SessionChatParams:
     input: str = ""
     agent_id: str = ""
     client_message_id: str = ""
+    files: Optional[List[V1MessageFile]] = None
     workspace_id: str = ""
 
 

--- a/libs/hibot/tests/test_chat_files_approve.py
+++ b/libs/hibot/tests/test_chat_files_approve.py
@@ -1,0 +1,152 @@
+"""Tests for chat() approve injection, file uploads, and CredentialConfig."""
+
+from __future__ import annotations
+
+import json
+
+from hibot import (
+    V1CredentialSecretInputParams,
+    V1MCPCredentialInputParams,
+    V1MCPNewParams,
+    V1MCPUpdateParams,
+    V1MessageFile,
+    V1SessionChatParams,
+)
+
+
+def test_chat_non_streaming_injects_approve_all(
+    client_factory, make_handler, ok_envelope, sse
+):
+    sse_body = (
+        b'event: run_completed\n'
+        b'data: {"message":{"ID":"m-1","Role":"assistant","Content":"ok"}}\n\n'
+    )
+    handler = make_handler([sse(sse_body)])
+    client = client_factory(handler)
+
+    msg = client.v1.sessions.chat(
+        "s-1",
+        V1SessionChatParams(input="hello", agent_id="agent-1"),
+    )
+    assert msg.id == "m-1"
+
+    body = json.loads(handler.calls[0].content)
+    assert body["Approve"] == "all"
+
+
+def test_chat_streaming_does_not_inject_approve(
+    client_factory, make_handler, ok_envelope, sse
+):
+    sse_body = (
+        b'event: run_completed\n'
+        b'data: {"message":{"ID":"m-1"}}\n\n'
+    )
+    handler = make_handler([sse(sse_body)])
+    client = client_factory(handler)
+
+    with client.v1.sessions.chat_streaming(
+        "s-1", V1SessionChatParams(input="hello", agent_id="agent-1")
+    ) as stream:
+        for _ in stream:
+            pass
+
+    body = json.loads(handler.calls[0].content)
+    assert "Approve" not in body
+
+
+def test_chat_supports_files_and_empty_content(
+    client_factory, make_handler, ok_envelope, sse
+):
+    sse_body = (
+        b'event: run_completed\n'
+        b'data: {"message":{"ID":"m-1"}}\n\n'
+    )
+    handler = make_handler([sse(sse_body)])
+    client = client_factory(handler)
+
+    client.v1.sessions.chat(
+        "s-1",
+        V1SessionChatParams(
+            agent_id="agent-1",
+            files=[
+                V1MessageFile(
+                    name="report.pdf",
+                    content_type="application/pdf",
+                    blob_id="blob-123",
+                )
+            ],
+        ),
+    )
+
+    body = json.loads(handler.calls[0].content)
+    # Content 缺省为空串；服务端允许仅传 Files。
+    assert body.get("Content", "") == ""
+    files = body["Files"]
+    assert len(files) == 1
+    assert files[0]["Name"] == "report.pdf"
+    assert files[0]["ContentType"] == "application/pdf"
+    assert files[0]["BlobID"] == "blob-123"
+
+
+def test_create_mcp_serializes_credential_config_secret_value(
+    client_factory, make_handler, ok_envelope
+):
+    handler = make_handler([ok_envelope({"ID": "mcp-1"})])
+    client = client_factory(handler)
+
+    client.v1.mcps.create(
+        V1MCPNewParams(
+            name="demo",
+            transport="streamable_http",
+            endpoint="https://example.com/mcp",
+            credential_config=V1MCPCredentialInputParams(
+                name="demo-cred",
+                provider_type="basic",
+                secrets=[
+                    V1CredentialSecretInputParams(
+                        key_name="token",
+                        secret_type="string",
+                        secret_value="s3cr3t",
+                    )
+                ],
+            ),
+        )
+    )
+
+    body = json.loads(handler.calls[0].content)
+    cfg = body["CredentialConfig"]
+    assert cfg["Name"] == "demo-cred"
+    assert cfg["ProviderType"] == "basic"
+    secret = cfg["Secrets"][0]
+    assert secret["KeyName"] == "token"
+    assert secret["SecretValue"] == "s3cr3t"
+    # 旧 Value 字段不应再出现。
+    assert "Value" not in secret
+    # 旧 Credential 字段（Name 引用）也不应再被发送。
+    assert "Credential" not in body
+
+
+def test_update_mcp_passes_credential_config(
+    client_factory, make_handler, ok_envelope
+):
+    handler = make_handler([ok_envelope({})])
+    client = client_factory(handler)
+
+    client.v1.mcps.update(
+        V1MCPUpdateParams(
+            id="mcp-1",
+            credential_config=V1MCPCredentialInputParams(
+                name="demo-cred",
+                secrets=[
+                    V1CredentialSecretInputParams(
+                        key_name="token",
+                        secret_value="new-secret",
+                    )
+                ],
+            ),
+        )
+    )
+
+    body = json.loads(handler.calls[0].content)
+    cfg = body["CredentialConfig"]
+    assert cfg["Secrets"][0]["SecretValue"] == "new-secret"

--- a/libs/hibot/tests/test_full_journey_offline.py
+++ b/libs/hibot/tests/test_full_journey_offline.py
@@ -14,11 +14,12 @@ import httpx
 from hibot import (
     V1AgentNewParams,
     V1AgentNewParamsToolUnion,
-    V1CredentialRefParams,
+    V1CredentialSecretInputParams,
     V1ManagedAgentMCPToolParams,
     V1ManagedAgentModelConfigParams,
     V1ManagedAgentResourceRefParams,
     V1ManagedAgentSkillToolParams,
+    V1MCPCredentialInputParams,
     V1MCPNewParams,
     V1ModelGetParams,
     V1PromptNewParams,
@@ -182,7 +183,17 @@ def test_full_journey_streaming_and_batch(
             name="e2e-mcp",
             transport="streamable_http",
             endpoint="http://mcp.local/mcp",
-            credential=V1CredentialRefParams(name="e2e-token"),
+            credential_config=V1MCPCredentialInputParams(
+                name="e2e-token",
+                provider_type="basic",
+                secrets=[
+                    V1CredentialSecretInputParams(
+                        key_name="token",
+                        secret_type="string",
+                        secret_value="e2e-token-value",
+                    )
+                ],
+            ),
         )
     )
     assert mcp.id, "mcp.id empty"


### PR DESCRIPTION
## 背景 / 动机
对齐内部 hibot-sdk 三项契约更新：
1. webchat 非流式 chat 自动注入 `Approve="all"`，避免调用方在批回复中重复审批
2. chat 输入支持文件 (`Files`)，且当 `Files` 非空时 `Content` 可为空
3. 凭证字段重命名 `Value → SecretValue`，引入 `CredentialConfig + Secrets` 内联结构

## 变更点
- `libs/hibot/hibot/v1/types.py`：`V1MessageFile` 增 `blob_id`；新增 `V1CredentialSecretInputParams` / `V1MCPCredentialInputParams` / `V1SkillCredentialInputParams`；`V1MCPNewParams` / `V1MCPUpdateParams` / `V1MCPTestConnectionParams` / `V1SkillNewParams` / `V1SkillUpdateParams` 改为 `credential_config`；`V1SessionChatParams` 增 `files`；删除旧 `V1CredentialRefParams`
- `libs/hibot/hibot/v1/sessions.py`：新增 `_chat_streaming(auto_approve_all)` 共享底座；非流式 chat 自动注入 `Approve="all"`，并支持 `Files` 透传
- `libs/hibot/hibot/v1/{mcps,skills}.py`：create / update / test_connection 改用 `CredentialConfig + Secrets[].secret_value`
- 测试：新增 `tests/test_chat_files_approve.py`；同步 `tests/test_full_journey_offline.py`

## 跨语言对等性
- Go：✅ 已落地（hiagent-go-sdk 同步 PR）
- Python：✅ 已落地（本 PR）
- Java：✅ 已落地（hiagent-java-sdk 同步 PR）
- CLI：✅ 已落地（hiagent-go-sdk cmd/hibot）

## 破坏式变更
是。`V1CredentialRefParams` / `V1MCPNewParams.credential` 下线；调用方需迁移到 `V1MCPCredentialInputParams` + `Secrets[].secret_value`。服务端响应字段同步由 `Value → SecretValue`。

## 验证方式
- 离线：
  - `cd libs/hibot && python -m pytest tests/ -v --ignore=tests/e2e` ✅ — 39 passed, 2 skipped
  - `ruff check libs/hibot` ✅
- 真实 E2E：触达集群但出现流式 `completed` 事件 final message.content 解析为空（三仓一致回归），属流式底座既有行为，超出本 PR 三项变更范围；本次 RealEnv 用例跳过
- 合规：`git diff --cached` 红线 grep 无命中；E2E 凭证仅 shell 临时 export，运行后 unset，未落盘

## 合规自检
未触发 §2.5 红线。已对全部 staged diff 跑过红线 grep，无命中。
