### PR TITLE
feat(python): align Hibot SDK with server API

### DIFF
--- a/libs/hibot/README.md
+++ b/libs/hibot/README.md
@@ -1,9 +1,9 @@
 # Hibot Python SDK
 
-Python client for the Hibot Managed Agent platform. Behaviorally aligned 1:1
-with the Go SDK in `hiagent-go-sdk/hibot` — same TOP routing, same VOLC v4
-signing, same SSE event normalization, same default-environment + peer
-injection semantics.
+Python client for the Hibot Managed Agent platform. The public API is aligned
+to `hibot_engine/api/idl/server.thrift`: every Hibot Action is signed for
+`hibot-server` at version `2026-04-23`; artifact uploads use the separate `up`
+service. The SDK also preserves VOLC v4 signing and SSE event normalization.
 
 > Distribution name: `hibot` (PyPI). Top-level import: `hibot`.
 >
@@ -38,7 +38,7 @@ cfg = hibot.Config(
 with hibot.Hibot(cfg) as client:
     # 1. Pick a base model (no Provider/Type filter ⇒ first match)
     model = client.v1.models.get(hibot.V1ModelGetParams(
-        model_name="doubao-seed-2.0-pro-260215",
+        model_name="doubao-seed-2-0-pro-260215",
     ))
 
     # 2. Create an agent (default Environment auto-selected)
@@ -83,39 +83,46 @@ Top-level (`hibot`):
 | `Config`                      | Endpoint + AK/SK + WorkspaceID + region/services overrides |
 | `APIError`                    | Raised on non-2xx or non-empty `ResponseMetadata.Error`    |
 | `V1*` types                   | All resource & param dataclasses (re-exported from `v1`)   |
-| `BASE_MODELS` / `BASE_MODEL_*`| Built-in aigw model catalog & constants                    |
+| `BASE_MODELS` / `BASE_MODEL_*`| Built-in model catalog & constants                         |
 
 Resource services live under `client.v1.*`:
 
 - `client.v1.uploads` — `upload_blob` (routes to `/up` subpath via `up` service)
-- `client.v1.environments` — `create / list / get / update / delete / default`
+- `client.v1.environments` — `create / list / get / update / delete / default / list_workspace_specs`
 - `client.v1.models` — `get / list / create / update / delete / list_providers / list_model_providers / get_model_provider / get_model_provider_credential_schema`
 - `client.v1.prompts` — `create / list / update / delete`
-- `client.v1.resources` — `create / list / update / delete / get_by_name / batch_get` (+ nested `client.v1.resources.directories`)
-- `client.v1.mcps` — `create / list / get / update / delete / test_connection / resolve`
-- `client.v1.skills` — `create / list / get / update / delete / list_versions / resolve_version`
-- `client.v1.agents` — `create / list / get / batch_get / update / delete`
-- `client.v1.sessions` — `create / list / get / get_by_key / archive / delete / list_messages / get_message / inject_message / chat / chat_streaming`
+- `client.v1.resources` — resource/directory CRUD plus `batch_create / batch_get / move`
+- `client.v1.mcps` — CRUD plus `batch_get / test_connection / resolve`
+- `client.v1.skills` — CRUD/version resolution plus parse, batch-get, and Ark Skill Hub operations
+- `client.v1.agents` — CRUD, batch-get, and `retry_create / stop / resume`
+- `client.v1.channels` — channel CRUD
+- `client.v1.sessions` — session/message CRUD, batch-get, timeline history, `chat / chat_streaming / chat_resume / approve / cancel_run`
+- `client.v1.runtime_api_keys` — runtime key create/list/reveal/update/delete
+- `client.v1.runs` — persisted Run list/detail read model
+- `client.v1.cron_jobs` — Cron CRUD, run history/sync, toggle, and run-now
+- `client.v1.observations` — Trace list, Span list, and Span detail
+- `client.v1.overview` — workspace overview aggregation
+- `client.v1.metrics` — overview, trend, TopK, and breakdown queries
+- `client.v1.memories` — MemoryStore and MemoryFile CRUD/search
 
 ## Routing & versioning
 
-| Domain         | Service (default)  | Version       |
-| -------------- | ------------------ | ------------- |
-| CRUD           | `hibot-server`     | `2026-04-23`  |
-| Streaming chat | `hibot-gateway`    | `2026-05-11`  |
-| Models         | `aigw`             | `2023-08-01`  |
-| Uploads        | `up` (under `/up`) | `2022-01-01`  |
+| Domain                         | Service (default)  | Version      |
+| ------------------------------ | ------------------ | ------------ |
+| Hibot API (CRUD/model/chat)    | `hibot-server`     | `2026-04-23` |
+| Uploads                        | `up` (under `/up`) | `2022-01-01` |
 
-All four service identifiers can be overridden on `Config` for private
-deployments (`server_service` / `gateway_service` / `model_service` /
-`up_service`).
+The active service identifiers can be overridden on `Config` for private
+deployments (`server_service` / `up_service`). The deprecated
+`gateway_service` and `model_service` inputs remain as compatibility aliases
+but all Hibot Actions are signed and routed with `server_service`.
 
 The SDK injects `WorkspaceID` only at the **top level** of each Action body
-(never inside `Payload`), exactly mirroring the Go SDK.
+(never inside `Payload`), matching the current server IDL.
 
 ## Stream events
 
-`V1SessionChatStream` normalizes the gateway’s several event-name dialects
+`V1SessionChatStream` normalizes the server’s several event-name dialects
 (message.chunk / message_delta / run_completed / message.failed / run_failed /
 tool_started / tool_completed / …) into the canonical three-state set:
 
@@ -142,7 +149,7 @@ Two helpers are available on the stream:
 Service methods reject empty required identifiers (e.g. `agent_id`, `session_id`)
 the same way the Go SDK does.
 
-## Field alignment with Go SDK
+## Field alignment with Hibot server
 
 The wire-format JSON schema is identical: response classes deserialize from
 PascalCase keys (e.g. `ID`, `WorkspaceID`, `CreatedAt`). Notable mappings that
@@ -163,9 +170,25 @@ Skill bindings use the **version ID** in the `Skills[].ID` slot — pass the
 pytest -q
 ```
 
-Tests are completely offline — they use `httpx.MockTransport` to inspect
+The normal suite is offline: it uses `httpx.MockTransport` to inspect
 URL/Action/Version/Authorization headers and request bodies, plus simulated
 SSE payloads to exercise the chat stream.
+
+Real create → runtime-ready → session → streaming Chat → synchronous Chat →
+cleanup tests are enabled when these variables are present:
+
+```bash
+export HIBOT_ENDPOINT="http://..."
+export HIBOT_AK="..."
+export HIBOT_SK="..."
+export HIBOT_WORKSPACE_ID="..."
+pytest -q libs/hibot/tests/test_real_env.py -s
+```
+
+`HIBOT_E2E_ENV_IMAGE_TYPE` and `HIBOT_E2E_MODEL_ID` can select a known-good
+runtime and model. The real test fails unless the Agent reaches
+`RuntimeStatus.Ready` and both Chat modes complete; created resources are
+removed in `finally` blocks.
 
 ## Differences from the Go SDK
 

--- a/libs/hibot/hibot/_config.py
+++ b/libs/hibot/hibot/_config.py
@@ -16,9 +16,10 @@ class Config:
     workspace_id: str
     region: str = _v.DEFAULT_REGION
     server_service: str = _v.SERVER_SERVICE
-    gateway_service: str = _v.GATEWAY_SERVICE
-    model_service: str = _v.AIGW_SERVICE
     up_service: str = _v.UP_SERVICE
+    # Deprecated compatibility inputs. All Hibot Actions use server_service.
+    gateway_service: str = ""
+    model_service: str = ""
     timeout: float = 30.0
     # Optional pre-built httpx.Client / httpx.AsyncClient — leave None to let
     # SDK build defaults internally.
@@ -32,9 +33,9 @@ class Config:
         self.workspace_id = (self.workspace_id or "").strip()
         self.region = (self.region or "").strip() or _v.DEFAULT_REGION
         self.server_service = (self.server_service or "").strip() or _v.SERVER_SERVICE
-        self.gateway_service = (self.gateway_service or "").strip() or _v.GATEWAY_SERVICE
-        self.model_service = (self.model_service or "").strip() or _v.AIGW_SERVICE
         self.up_service = (self.up_service or "").strip() or _v.UP_SERVICE
+        self.gateway_service = self.server_service
+        self.model_service = self.server_service
 
         if not self.endpoint:
             raise ValueError("hibot: endpoint is required")

--- a/libs/hibot/hibot/_request.py
+++ b/libs/hibot/hibot/_request.py
@@ -29,7 +29,9 @@ class Requester:
     def __init__(self, config: Config) -> None:
         self._cfg = config
         self._client: Optional[httpx.Client] = None
-        if config.http_client is not None and isinstance(config.http_client, httpx.Client):
+        if config.http_client is not None and isinstance(
+            config.http_client, httpx.Client
+        ):
             self._client = config.http_client
             self._owns_client = False
         else:
@@ -48,9 +50,20 @@ class Requester:
     # -------- public ops --------
 
     def do_action(self, action: Action) -> Optional[Any]:
+        return self._do_action(action)
+
+    def do_long_action(self, action: Action) -> Optional[Any]:
+        """Execute a non-streaming action without the client's total timeout."""
+        return self._do_action(action, timeout=None)
+
+    def _do_action(
+        self, action: Action, timeout: Any = httpx.USE_CLIENT_DEFAULT
+    ) -> Optional[Any]:
         body_bytes = self._marshal_body(action.body)
         url, headers = self._build_request(action, body_bytes, "application/json", None)
-        resp = self._client.request("POST", url, content=body_bytes, headers=headers)
+        resp = self._client.request(
+            "POST", url, content=body_bytes, headers=headers, timeout=timeout
+        )
         return decode_top(resp.status_code, resp.content)
 
     def do_raw_action(
@@ -60,7 +73,9 @@ class Requester:
         content_type: str,
         query: Optional[Mapping[str, str]] = None,
     ) -> Optional[Any]:
-        url, headers = self._build_request(action, body or b"", content_type or "application/octet-stream", query)
+        url, headers = self._build_request(
+            action, body or b"", content_type or "application/octet-stream", query
+        )
         resp = self._client.request("POST", url, content=body or b"", headers=headers)
         return decode_top(resp.status_code, resp.content)
 
@@ -69,7 +84,9 @@ class Requester:
         action.stream = True
         url, headers = self._build_request(action, body_bytes, "application/json", None)
         # SSE streams may run beyond the default timeout.
-        ctx = self._client.stream("POST", url, content=body_bytes, headers=headers, timeout=None)
+        ctx = self._client.stream(
+            "POST", url, content=body_bytes, headers=headers, timeout=None
+        )
         resp = ctx.__enter__()
         return _StreamResponse(ctx, resp)
 
@@ -88,7 +105,7 @@ class Requester:
         content_type: str,
         query: Optional[Mapping[str, str]],
     ):
-        # Compose URL: TOP gateway hosts the up service under /up
+        # Compose URL: TOP hosts the up service under /up
         # subpath; other services share the root path.
         parts = urlsplit(self._cfg.endpoint)
         path = parts.path or ""
@@ -98,6 +115,7 @@ class Requester:
         # Preserve any pre-existing query on the endpoint (rare).
         if parts.query:
             from urllib.parse import parse_qsl
+
             q.update(dict(parse_qsl(parts.query, keep_blank_values=True)))
         q["Action"] = action.action
         q["Version"] = action.version
@@ -168,7 +186,11 @@ def _default_encoder(o: Any) -> Any:
     if hasattr(o, "to_dict") and callable(o.to_dict):
         return o.to_dict()
     if hasattr(o, "__dict__"):
-        return {k: v for k, v in o.__dict__.items() if not k.startswith("_") and v is not None}
+        return {
+            k: v
+            for k, v in o.__dict__.items()
+            if not k.startswith("_") and v is not None
+        }
     raise TypeError(f"hibot: cannot encode object of type {type(o).__name__}")
 
 

--- a/libs/hibot/hibot/_version.py
+++ b/libs/hibot/hibot/_version.py
@@ -3,16 +3,18 @@
 DEFAULT_REGION = "cn-north-1"
 
 SERVER_SERVICE = "hibot-server"
-GATEWAY_SERVICE = "hibot-gateway"
-# AIGW DestService: the TOP gateway registers model/provider
-# Actions under this exact service name; "aigw-server" returns InvalidAction.
-AIGW_SERVICE = "aigw"
 UP_SERVICE = "up"
+
+# Backward-compatible aliases. Hibot Actions no longer route to separate
+# gateway/model services; callers importing the old constants receive the
+# effective server values.
+GATEWAY_SERVICE = SERVER_SERVICE
+AIGW_SERVICE = SERVER_SERVICE
 
 V1 = "v1"
 
 # TOP-registered API Versions (YYYY-MM-DD).
 SERVER_VERSION = "2026-04-23"
-CHAT_VERSION = "2026-05-11"
-MODEL_VERSION = "2023-08-01"
 UP_VERSION = "2022-01-01"
+CHAT_VERSION = SERVER_VERSION
+MODEL_VERSION = SERVER_VERSION

--- a/libs/hibot/hibot/client.py
+++ b/libs/hibot/hibot/client.py
@@ -21,8 +21,6 @@ class Client:
         self._requester = Requester(config)
         services = Services(
             server=config.server_service,
-            gateway=config.gateway_service,
-            model=config.model_service,
             up=config.up_service,
         )
         self.v1 = V1Client(self._requester, services)

--- a/libs/hibot/hibot/v1/__init__.py
+++ b/libs/hibot/hibot/v1/__init__.py
@@ -16,11 +16,19 @@ from .base_models import (
     BASE_MODEL_TYPE_VISION,
     BASE_MODELS,
 )
+from .channels import ChannelsService
+from .cron_jobs import CronJobsService
 from .environments import EnvironmentsService
 from .mcps import MCPsService
+from .memories import MemoriesService
+from .metrics import MetricsService
 from .models import ModelsService
+from .observations import ObservationsService
+from .overview import OverviewService
 from .prompts import PromptsService
 from .resources import DirectoriesService, ResourcesService
+from .runs import RunsService
+from .runtime_api_keys import RuntimeAPIKeysService
 from .sessions import SessionsService
 from .skills import SkillsService
 from .stream import V1SessionChatStream, decode_chat_event, normalize_chat_event_name
@@ -32,11 +40,19 @@ __all__ = [
     "Services",
     # services
     "AgentsService",
+    "ChannelsService",
+    "CronJobsService",
     "EnvironmentsService",
     "MCPsService",
+    "MemoriesService",
+    "MetricsService",
     "ModelsService",
+    "ObservationsService",
+    "OverviewService",
     "PromptsService",
     "ResourcesService",
+    "RunsService",
+    "RuntimeAPIKeysService",
     "DirectoriesService",
     "SessionsService",
     "SkillsService",

--- a/libs/hibot/hibot/v1/_client.py
+++ b/libs/hibot/hibot/v1/_client.py
@@ -10,8 +10,6 @@ from .._request import Requester
 @dataclass
 class Services:
     server: str
-    gateway: str
-    model: str
     up: str
 
 
@@ -24,11 +22,19 @@ class V1Client:
 
         # Lazy import to avoid circular references.
         from .agents import AgentsService
+        from .channels import ChannelsService
+        from .cron_jobs import CronJobsService
         from .environments import EnvironmentsService
         from .mcps import MCPsService
+        from .memories import MemoriesService
+        from .metrics import MetricsService
         from .models import ModelsService
+        from .observations import ObservationsService
+        from .overview import OverviewService
         from .prompts import PromptsService
         from .resources import ResourcesService
+        from .runs import RunsService
+        from .runtime_api_keys import RuntimeAPIKeysService
         from .sessions import SessionsService
         from .skills import SkillsService
         from .uploads import UploadsService
@@ -41,7 +47,15 @@ class V1Client:
         self.mcps = MCPsService(self)
         self.skills = SkillsService(self)
         self.agents = AgentsService(self)
+        self.channels = ChannelsService(self)
         self.sessions = SessionsService(self)
+        self.runtime_api_keys = RuntimeAPIKeysService(self)
+        self.runs = RunsService(self)
+        self.cron_jobs = CronJobsService(self)
+        self.observations = ObservationsService(self)
+        self.overview = OverviewService(self)
+        self.metrics = MetricsService(self)
+        self.memories = MemoriesService(self)
 
     @property
     def workspace_id(self) -> str:

--- a/libs/hibot/hibot/v1/_helpers.py
+++ b/libs/hibot/hibot/v1/_helpers.py
@@ -3,7 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import fields, is_dataclass
-from typing import Any, Dict, List, Optional, Type, TypeVar
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 T = TypeVar("T")
 
@@ -18,6 +28,10 @@ def from_dict(cls: Type[T], data: Any) -> Optional[T]:
         return None
     if not is_dataclass(cls):
         raise TypeError(f"from_dict requires a dataclass; got {cls!r}")
+    try:
+        type_hints = get_type_hints(cls)
+    except (NameError, TypeError):
+        type_hints = {}
     init_kwargs: Dict[str, Any] = {}
     for fld in fields(cls):
         json_name = fld.metadata.get("json", fld.name) if fld.metadata else fld.name
@@ -25,7 +39,9 @@ def from_dict(cls: Type[T], data: Any) -> Optional[T]:
         for key in (json_name, fld.name):
             if key in data:
                 value = data[key]
-                init_kwargs[fld.name] = _decode_field(fld, value)
+                init_kwargs[fld.name] = _decode_field(
+                    type_hints.get(fld.name, fld.type), value
+                )
                 break
     try:
         return cls(**init_kwargs)  # type: ignore[call-arg]
@@ -35,40 +51,52 @@ def from_dict(cls: Type[T], data: Any) -> Optional[T]:
         # Build a "safe" version by providing defaults for missing required fields.
         instance = cls.__new__(cls)  # type: ignore[call-arg]
         for fld in fields(cls):
-            setattr(instance, fld.name, init_kwargs.get(fld.name, _default_for_field(fld)))
+            setattr(
+                instance, fld.name, init_kwargs.get(fld.name, _default_for_field(fld))
+            )
         return instance
 
 
-def _decode_field(fld, value: Any) -> Any:
+def _decode_field(field_type: Any, value: Any) -> Any:
     # Detect List[X] of dataclass and dict-of-X
-    inner = _list_of_dataclass(fld.type)
+    inner = _list_of_dataclass(field_type)
     if inner and isinstance(value, list):
         return [from_dict(inner, v) if isinstance(v, dict) else v for v in value]
-    nested = _dataclass_type(fld.type)
+    nested = _dataclass_type(field_type)
     if nested and isinstance(value, dict):
         return from_dict(nested, value)
     return value
 
 
 def _dataclass_type(tp: Any):
-    # str type-hints (PEP 563) won't resolve here; we rely on generic dict pass-through.
     if isinstance(tp, type) and is_dataclass(tp):
         return tp
+    for arg in get_args(tp):
+        if isinstance(arg, type) and is_dataclass(arg):
+            return arg
     return None
 
 
 def _list_of_dataclass(tp: Any):
     # Best-effort: handle typing.List[X]
-    origin = getattr(tp, "__origin__", None)
+    origin = get_origin(tp)
     if origin is list:
-        args = getattr(tp, "__args__", ())
+        args = get_args(tp)
         if args and isinstance(args[0], type) and is_dataclass(args[0]):
             return args[0]
+    for arg in get_args(tp):
+        origin = get_origin(arg)
+        if origin is list:
+            args = get_args(arg)
+            if args and isinstance(args[0], type) and is_dataclass(args[0]):
+                return args[0]
     return None
 
 
 def _default_for_field(fld) -> Any:
-    if fld.default is not None and fld.default is not getattr(fld, "_MISSING_TYPE", None):
+    if fld.default is not None and fld.default is not getattr(
+        fld, "_MISSING_TYPE", None
+    ):
         try:
             from dataclasses import MISSING
 

--- a/libs/hibot/hibot/v1/_server_service.py
+++ b/libs/hibot/hibot/v1/_server_service.py
@@ -1,0 +1,41 @@
+"""Shared helpers for hibot-server V1 services."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from .._request import Action
+from .._version import SERVER_VERSION
+from .types import V1PageInput
+
+
+class ServerService:
+    def __init__(self, v1) -> None:
+        self._v1 = v1
+
+    def _action(self, name: str, body: Any):
+        return self._v1.requester.do_action(
+            Action(
+                service=self._v1.services.server,
+                version=SERVER_VERSION,
+                action=name,
+                body=body,
+            )
+        )
+
+
+def encode_page(page: Optional[V1PageInput]) -> Optional[dict]:
+    if page is None:
+        return None
+    return {"PageNum": page.page_num, "PageSize": page.page_size}
+
+
+def put_if(body: dict, key: str, value: Any, *, allow_empty: bool = False) -> None:
+    if value is None:
+        return
+    if not allow_empty and value == "":
+        return
+    body[key] = value
+
+
+__all__ = ["ServerService", "encode_page", "put_if"]

--- a/libs/hibot/hibot/v1/agents.py
+++ b/libs/hibot/hibot/v1/agents.py
@@ -14,6 +14,9 @@ from .types import (
     V1AgentGetParams,
     V1AgentListParams,
     V1AgentNewParams,
+    V1AgentResumeParams,
+    V1AgentRetryCreateParams,
+    V1AgentStopParams,
     V1AgentUpdateParams,
 )
 
@@ -43,9 +46,20 @@ def _build_tool_bindings(tools):
         return skills, mcps
     for t in tools:
         if t.of_skill is not None and t.of_skill.skill_version_id:
-            skills.append({"ID": t.of_skill.skill_version_id})
+            binding = {"ID": t.of_skill.skill_version_id}
+            if t.of_skill.enabled is not None:
+                binding["Enabled"] = t.of_skill.enabled
+            skills.append(binding)
         if t.of_mcp is not None and t.of_mcp.id:
-            mcps.append({"ID": t.of_mcp.id, "Enabled": True})
+            binding = {
+                "ID": t.of_mcp.id,
+                "Enabled": True if t.of_mcp.enabled is None else t.of_mcp.enabled,
+            }
+            if t.of_mcp.tool_allowlist is not None:
+                binding["ToolAllowlist"] = list(t.of_mcp.tool_allowlist)
+            if t.of_mcp.tool_denylist is not None:
+                binding["ToolDenylist"] = list(t.of_mcp.tool_denylist)
+            mcps.append(binding)
     return skills, mcps
 
 
@@ -55,7 +69,12 @@ class AgentsService:
 
     def _action(self, name: str, body):
         return self._v1.requester.do_action(
-            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+            Action(
+                service=self._v1.services.server,
+                version=SERVER_VERSION,
+                action=name,
+                body=body,
+            )
         )
 
     def create(self, params: Optional[V1AgentNewParams] = None, **kwargs) -> V1Agent:
@@ -74,6 +93,18 @@ class AgentsService:
             body["WorkspaceID"] = params.workspace_id
         if params.system is not None:
             body["SystemPrompt"] = params.system
+        for key, value in (
+            ("Description", params.description),
+            ("Channels", params.channels),
+            ("Config", params.config),
+            ("Metadata", params.metadata),
+            ("Icon", params.icon),
+            ("ApiProtocolType", params.api_protocol_type),
+            ("ModelInteractiveMode", params.model_interactive_mode),
+            ("EgressCredentials", params.egress_credentials),
+        ):
+            if value is not None:
+                body[key] = value
         resources = _build_resource_input(params.resources)
         if resources:
             body["Resources"] = resources
@@ -139,18 +170,40 @@ class AgentsService:
             for t in params.skills:
                 if not t.skill_version_id:
                     continue
-                skills_list.append({"ID": t.skill_version_id})
+                binding = {"ID": t.skill_version_id}
+                if t.enabled is not None:
+                    binding["Enabled"] = t.enabled
+                skills_list.append(binding)
             body["Skills"] = skills_list
         if params.mcps is not None:
             mcps_list = []
             for t in params.mcps:
                 if not t.id:
                     continue
-                mcps_list.append({"ID": t.id, "Enabled": True})
+                binding = {
+                    "ID": t.id,
+                    "Enabled": True if t.enabled is None else t.enabled,
+                }
+                if t.tool_allowlist is not None:
+                    binding["ToolAllowlist"] = list(t.tool_allowlist)
+                if t.tool_denylist is not None:
+                    binding["ToolDenylist"] = list(t.tool_denylist)
+                mcps_list.append(binding)
             body["MCPs"] = mcps_list
         if params.reset_resources or params.resources:
             resources = _build_resource_input(params.resources)
             body["Resources"] = resources or {}
+        for key, value in (
+            ("Config", params.config),
+            ("Metadata", params.metadata),
+            ("MemoryStores", params.memory_stores),
+            ("Icon", params.icon),
+            ("ApiProtocolType", params.api_protocol_type),
+            ("ModelInteractiveMode", params.model_interactive_mode),
+            ("EgressCredentials", params.egress_credentials),
+        ):
+            if value is not None:
+                body[key] = value
         self._action("UpdateAgent", body)
 
     def delete(self, params: V1AgentDeleteParams) -> None:
@@ -160,3 +213,20 @@ class AgentsService:
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         self._action("DeleteAgent", body)
+
+    def retry_create(self, params: V1AgentRetryCreateParams) -> None:
+        self._agent_action("RetryCreateAgent", params.agent_id, params.workspace_id)
+
+    def stop(self, params: V1AgentStopParams) -> None:
+        self._agent_action("StopAgent", params.agent_id, params.workspace_id)
+
+    def resume(self, params: V1AgentResumeParams) -> None:
+        self._agent_action("ResumeAgent", params.agent_id, params.workspace_id)
+
+    def _agent_action(self, action: str, agent_id: str, workspace_id: str) -> None:
+        if not agent_id:
+            raise ValueError("hibot: agent id is required")
+        body = {"AgentID": agent_id}
+        if workspace_id:
+            body["WorkspaceID"] = workspace_id
+        self._action(action, body)

--- a/libs/hibot/hibot/v1/base_models.py
+++ b/libs/hibot/hibot/v1/base_models.py
@@ -1,4 +1,4 @@
-"""aigw built-in base models (mirrors go/hibot/v1/base_models.go).
+"""Built-in base models exposed by the server model API.
 
 Generated from a real ListModelProvider call against the cluster.
 """

--- a/libs/hibot/hibot/v1/channels.py
+++ b/libs/hibot/hibot/v1/channels.py
@@ -1,0 +1,112 @@
+"""V1 Channel service."""
+
+from __future__ import annotations
+
+from typing import List
+
+from ._helpers import from_dict, list_from_items
+from ._server_service import ServerService, put_if
+from .types import (
+    V1Channel,
+    V1ChannelDeleteParams,
+    V1ChannelGetParams,
+    V1ChannelListParams,
+    V1ChannelNewParams,
+    V1ChannelUpdateParams,
+    V1FeishuChannelConfigParams,
+    V1WeComChannelConfigParams,
+)
+
+
+def _feishu_config(params: V1FeishuChannelConfigParams) -> dict:
+    body = {"AppID": params.app_id, "AppSecret": params.app_secret}
+    for key, value in (
+        ("EncryptKey", params.encrypt_key),
+        ("VerificationToken", params.verification_token),
+        ("Domain", params.domain),
+        ("ConnectionMode", params.connection_mode),
+        ("WebhookPath", params.webhook_path),
+        ("RequireMention", params.require_mention),
+        ("RenderMode", params.render_mode),
+        ("Streaming", params.streaming),
+        ("ReactionLevel", params.reaction_level),
+        ("TextChunkLimit", params.text_chunk_limit),
+        ("MediaMaxMB", params.media_max_mb),
+        ("BlockReply", params.block_reply),
+    ):
+        put_if(body, key, value, allow_empty=True)
+    return body
+
+
+def _wecom_config(params: V1WeComChannelConfigParams) -> dict:
+    return {"BotID": params.bot_id, "Secret": params.secret}
+
+
+def _channel_payload(params) -> dict:
+    body = {}
+    for key, value in (
+        ("Name", params.name),
+        ("ChannelType", params.channel_type),
+        ("DmPolicy", params.dm_policy),
+        ("GroupPolicy", params.group_policy),
+        ("Allowlist", params.allowlist),
+    ):
+        put_if(body, key, value, allow_empty=isinstance(params, V1ChannelUpdateParams))
+    if params.feishu_config is not None:
+        body["FeishuConfig"] = _feishu_config(params.feishu_config)
+    if params.wecom_config is not None:
+        body["WeComConfig"] = _wecom_config(params.wecom_config)
+    return body
+
+
+class ChannelsService(ServerService):
+    def create(self, params: V1ChannelNewParams) -> V1Channel:
+        if not params.agent_id or not params.name:
+            raise ValueError("hibot: channel agent id and name are required")
+        payload = _channel_payload(params)
+        payload["AgentID"] = params.agent_id
+        body = {"Payload": payload}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("CreateChannel", body)
+        new_id = result.get("ID") if isinstance(result, dict) else None
+        if not new_id:
+            raise ValueError("hibot: create channel response missing ID")
+        return V1Channel(id=new_id, agent_id=params.agent_id, name=params.name)
+
+    def list(
+        self, params: V1ChannelListParams = V1ChannelListParams()
+    ) -> List[V1Channel]:
+        body = {}
+        put_if(body, "AgentID", params.agent_id)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        return list_from_items(V1Channel, self._action("ListChannels", body))
+
+    def get(self, params: V1ChannelGetParams) -> V1Channel:
+        if not params.channel_id:
+            raise ValueError("hibot: channel id is required")
+        body = {"ChannelID": params.channel_id}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetChannel", body)
+        decoded = from_dict(V1Channel, result) or V1Channel()
+        if not decoded.id:
+            raise ValueError("hibot: get channel response missing ID")
+        return decoded
+
+    def update(self, params: V1ChannelUpdateParams) -> None:
+        if not params.channel_id:
+            raise ValueError("hibot: channel id is required")
+        payload = _channel_payload(params)
+        put_if(payload, "TargetAgentID", params.target_agent_id, allow_empty=True)
+        body = {"ChannelID": params.channel_id, "Payload": payload}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        self._action("UpdateChannel", body)
+
+    def delete(self, params: V1ChannelDeleteParams) -> None:
+        if not params.channel_id:
+            raise ValueError("hibot: channel id is required")
+        body = {"ChannelID": params.channel_id}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        self._action("DeleteChannel", body)
+
+
+__all__ = ["ChannelsService"]

--- a/libs/hibot/hibot/v1/cron_jobs.py
+++ b/libs/hibot/hibot/v1/cron_jobs.py
@@ -1,0 +1,175 @@
+"""V1 Cron job service."""
+
+from __future__ import annotations
+
+from ._helpers import from_dict, list_from_items
+from ._server_service import ServerService, encode_page, put_if
+from .types import (
+    V1CronJob,
+    V1CronJobCreateResult,
+    V1CronJobDeleteParams,
+    V1CronJobGetParams,
+    V1CronJobList,
+    V1CronJobListParams,
+    V1CronJobNewParams,
+    V1CronJobRun,
+    V1CronJobRunList,
+    V1CronJobRunListParams,
+    V1CronJobRunNowParams,
+    V1CronJobRunNowResult,
+    V1CronJobRunSync,
+    V1CronJobRunSyncList,
+    V1CronJobRunSyncListParams,
+    V1CronJobToggleParams,
+    V1CronJobUpdateParams,
+    V1Page,
+)
+
+
+class CronJobsService(ServerService):
+    def list(
+        self, params: V1CronJobListParams = V1CronJobListParams()
+    ) -> V1CronJobList:
+        body = {}
+        put_if(body, "AgentID", params.agent_id)
+        put_if(body, "Source", params.source)
+        put_if(body, "Enabled", params.enabled, allow_empty=True)
+        put_if(body, "Page", encode_page(params.page))
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("ListCronJobs", body)
+        out = V1CronJobList()
+        if isinstance(result, dict):
+            out.items = list_from_items(V1CronJob, result)
+            out.page = from_dict(V1Page, result.get("Page"))
+        return out
+
+    def list_runs(self, params: V1CronJobRunListParams) -> V1CronJobRunList:
+        if not params.cron_job_id:
+            raise ValueError("hibot: cron job id is required")
+        body = {"CronJobID": params.cron_job_id}
+        put_if(body, "Page", encode_page(params.page))
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("ListCronJobRuns", body)
+        out = V1CronJobRunList()
+        if isinstance(result, dict):
+            out.items = list_from_items(V1CronJobRun, result)
+            out.page = from_dict(V1Page, result.get("Page"))
+        return out
+
+    def list_runs_for_sync(
+        self, params: V1CronJobRunSyncListParams = V1CronJobRunSyncListParams()
+    ) -> V1CronJobRunSyncList:
+        body = {}
+        put_if(body, "CursorUpdatedAt", params.cursor_updated_at)
+        put_if(body, "CursorID", params.cursor_id)
+        put_if(body, "PageSize", params.page_size, allow_empty=True)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("ListCronJobRunsForSync", body)
+        out = from_dict(V1CronJobRunSyncList, result) or V1CronJobRunSyncList()
+        if isinstance(result, dict):
+            out.items = list_from_items(V1CronJobRunSync, result)
+        return out
+
+    def get(self, params: V1CronJobGetParams) -> V1CronJob:
+        if not params.cron_job_id:
+            raise ValueError("hibot: cron job id is required")
+        body = {"CronJobID": params.cron_job_id}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetCronJob", body)
+        decoded = from_dict(V1CronJob, result) or V1CronJob()
+        if not decoded.id:
+            raise ValueError("hibot: get cron job response missing ID")
+        return decoded
+
+    def create(self, params: V1CronJobNewParams) -> V1CronJobCreateResult:
+        required = (
+            params.agent_id,
+            params.name,
+            params.prompt,
+            params.schedule_type,
+            params.schedule_value,
+            params.delivery_channel,
+            params.delivery_to,
+        )
+        if not all(required):
+            raise ValueError("hibot: cron job required fields are missing")
+        body = {
+            "AgentID": params.agent_id,
+            "Name": params.name,
+            "Prompt": params.prompt,
+            "ScheduleType": params.schedule_type,
+            "ScheduleValue": params.schedule_value,
+            "DeliveryChannel": params.delivery_channel,
+            "DeliveryTo": params.delivery_to,
+        }
+        for key, value in (
+            ("Description", params.description),
+            ("ScheduleTimezone", params.schedule_timezone),
+            ("Enabled", params.enabled),
+            ("Config", params.config),
+            ("CorrelationID", params.correlation_id),
+            ("WorkspaceID", params.workspace_id),
+        ):
+            put_if(
+                body,
+                key,
+                value,
+                allow_empty=value is not None and not isinstance(value, str),
+            )
+        result = self._action("CreateCronJob", body)
+        decoded = from_dict(V1CronJobCreateResult, result) or V1CronJobCreateResult()
+        if not decoded.cron_job_id:
+            raise ValueError("hibot: create cron job response missing CronJobID")
+        return decoded
+
+    def update(self, params: V1CronJobUpdateParams) -> None:
+        if not params.cron_job_id:
+            raise ValueError("hibot: cron job id is required")
+        body = {"CronJobID": params.cron_job_id}
+        for key, value in (
+            ("Name", params.name),
+            ("Description", params.description),
+            ("Prompt", params.prompt),
+            ("ScheduleType", params.schedule_type),
+            ("ScheduleValue", params.schedule_value),
+            ("ScheduleTimezone", params.schedule_timezone),
+            ("DeliveryChannel", params.delivery_channel),
+            ("DeliveryTo", params.delivery_to),
+            ("Enabled", params.enabled),
+            ("Config", params.config),
+            ("UpdateFields", params.update_fields),
+        ):
+            put_if(body, key, value, allow_empty=True)
+        put_if(body, "CorrelationID", params.correlation_id)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        self._action("UpdateCronJob", body)
+
+    def delete(self, params: V1CronJobDeleteParams) -> None:
+        if not params.cron_job_id:
+            raise ValueError("hibot: cron job id is required")
+        body = {"CronJobID": params.cron_job_id}
+        put_if(body, "CancelRunning", params.cancel_running, allow_empty=True)
+        put_if(body, "CorrelationID", params.correlation_id)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        self._action("DeleteCronJob", body)
+
+    def toggle(self, params: V1CronJobToggleParams) -> V1CronJob:
+        if not params.cron_job_id:
+            raise ValueError("hibot: cron job id is required")
+        body = {"CronJobID": params.cron_job_id, "Enabled": params.enabled}
+        put_if(body, "CorrelationID", params.correlation_id)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("ToggleCronJob", body)
+        return from_dict(V1CronJob, result) or V1CronJob()
+
+    def run_now(self, params: V1CronJobRunNowParams) -> V1CronJobRunNowResult:
+        if not params.cron_job_id:
+            raise ValueError("hibot: cron job id is required")
+        body = {"CronJobID": params.cron_job_id}
+        put_if(body, "CorrelationID", params.correlation_id)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("RunCronJobNow", body)
+        return from_dict(V1CronJobRunNowResult, result) or V1CronJobRunNowResult()
+
+
+__all__ = ["CronJobsService"]

--- a/libs/hibot/hibot/v1/environments.py
+++ b/libs/hibot/hibot/v1/environments.py
@@ -11,6 +11,7 @@ from .types import (
     V1Environment,
     V1EnvironmentNewParams,
     V1EnvironmentUpdateParams,
+    V1WorkspaceSpec,
 )
 
 
@@ -20,7 +21,12 @@ class EnvironmentsService:
 
     def _action(self, name: str, body):
         return self._v1.requester.do_action(
-            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+            Action(
+                service=self._v1.services.server,
+                version=SERVER_VERSION,
+                action=name,
+                body=body,
+            )
         )
 
     def create(self, **kwargs) -> V1Environment:
@@ -42,6 +48,8 @@ class EnvironmentsService:
             payload["PVCSize"] = params.pvc_size
         if params.data_path:
             payload["DataPath"] = params.data_path
+        if params.spec_code:
+            payload["SpecCode"] = params.spec_code
         body = {"Payload": payload}
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
@@ -92,6 +100,8 @@ class EnvironmentsService:
             payload["PVCSize"] = params.pvc_size
         if params.data_path is not None:
             payload["DataPath"] = params.data_path
+        if params.spec_code is not None:
+            payload["SpecCode"] = params.spec_code
         body = {"EnvID": params.env_id, "Payload": payload}
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
@@ -104,6 +114,12 @@ class EnvironmentsService:
         if workspace_id:
             body["WorkspaceID"] = workspace_id
         self._action("DeleteEnv", body)
+
+    def list_workspace_specs(self) -> List[V1WorkspaceSpec]:
+        result = self._action("ListWorkspaceSpecs", {})
+        if not isinstance(result, dict):
+            return []
+        return list_from_items(V1WorkspaceSpec, {"Items": result.get("Specs", [])})
 
     def default(self, *, workspace_id: str = "") -> V1Environment:
         items = self.list(workspace_id=workspace_id)

--- a/libs/hibot/hibot/v1/mcps.py
+++ b/libs/hibot/hibot/v1/mcps.py
@@ -9,6 +9,7 @@ from .._version import SERVER_VERSION
 from ._helpers import from_dict, list_from_items
 from .types import (
     V1MCP,
+    V1MCPBatchGetParams,
     V1MCPCredentialInputParams,
     V1MCPDeleteParams,
     V1MCPGetParams,
@@ -58,7 +59,12 @@ class MCPsService:
 
     def _action(self, name: str, body):
         return self._v1.requester.do_action(
-            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+            Action(
+                service=self._v1.services.server,
+                version=SERVER_VERSION,
+                action=name,
+                body=body,
+            )
         )
 
     def create(self, params: V1MCPNewParams) -> V1MCP:
@@ -81,7 +87,9 @@ class MCPsService:
         if params.auth_type:
             body["AuthType"] = params.auth_type
         if params.credential_config is not None:
-            body["CredentialConfig"] = _credential_config_to_dict(params.credential_config)
+            body["CredentialConfig"] = _credential_config_to_dict(
+                params.credential_config
+            )
         if params.tool_allowlist is not None:
             body["ToolAllowlist"] = list(params.tool_allowlist)
         if params.tool_denylist is not None:
@@ -98,7 +106,12 @@ class MCPsService:
         new_id = result.get("ID") if isinstance(result, dict) else None
         if not new_id:
             raise ValueError("hibot: create mcp response missing ID")
-        return V1MCP(id=new_id, name=params.name, transport=params.transport, endpoint=params.endpoint)
+        return V1MCP(
+            id=new_id,
+            name=params.name,
+            transport=params.transport,
+            endpoint=params.endpoint,
+        )
 
     def list(self, params: V1MCPListParams = V1MCPListParams()) -> List[V1MCP]:
         body = {}
@@ -110,7 +123,21 @@ class MCPsService:
             body["Source"] = params.source
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
+        if params.page is not None:
+            body["Page"] = {
+                "PageNum": params.page.page_num,
+                "PageSize": params.page.page_size,
+            }
         result = self._action("ListMCPs", body)
+        return list_from_items(V1MCP, result)
+
+    def batch_get(self, params: V1MCPBatchGetParams) -> List[V1MCP]:
+        if not params.ids:
+            raise ValueError("hibot: mcp IDs are required")
+        body = {"IDs": list(params.ids)}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("BatchGetMCPs", body)
         return list_from_items(V1MCP, result)
 
     def get(self, params: V1MCPGetParams) -> V1MCP:
@@ -150,7 +177,9 @@ class MCPsService:
         if params.auth_type is not None:
             body["AuthType"] = params.auth_type
         if params.credential_config is not None:
-            body["CredentialConfig"] = _credential_config_to_dict(params.credential_config)
+            body["CredentialConfig"] = _credential_config_to_dict(
+                params.credential_config
+            )
         if params.tool_allowlist is not None:
             body["ToolAllowlist"] = list(params.tool_allowlist)
         if params.tool_denylist is not None:
@@ -173,7 +202,9 @@ class MCPsService:
             body["WorkspaceID"] = params.workspace_id
         self._action("DeleteMCP", body)
 
-    def test_connection(self, params: V1MCPTestConnectionParams) -> V1MCPTestConnectionResult:
+    def test_connection(
+        self, params: V1MCPTestConnectionParams
+    ) -> V1MCPTestConnectionResult:
         body = {}
         if params.transport:
             body["Transport"] = params.transport
@@ -190,20 +221,26 @@ class MCPsService:
         if params.auth_type:
             body["AuthType"] = params.auth_type
         if params.credential_config is not None:
-            body["CredentialConfig"] = _credential_config_to_dict(params.credential_config)
+            body["CredentialConfig"] = _credential_config_to_dict(
+                params.credential_config
+            )
         if params.timeout:
             body["Timeout"] = params.timeout
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         result = self._action("TestMCPConnection", body)
-        return from_dict(V1MCPTestConnectionResult, result) or V1MCPTestConnectionResult()
+        return (
+            from_dict(V1MCPTestConnectionResult, result) or V1MCPTestConnectionResult()
+        )
 
     def resolve(self, params: V1MCPResolveParams) -> V1MCP:
         if params.id:
             return V1MCP(id=params.id, name=params.name)
         if not params.name:
             raise ValueError("hibot: mcp id or name is required")
-        items = self.list(V1MCPListParams(keyword=params.name, workspace_id=params.workspace_id))
+        items = self.list(
+            V1MCPListParams(keyword=params.name, workspace_id=params.workspace_id)
+        )
         for item in items:
             if item.name == params.name and item.id:
                 return item

--- a/libs/hibot/hibot/v1/memories.py
+++ b/libs/hibot/hibot/v1/memories.py
@@ -1,0 +1,156 @@
+"""V1 memory store and memory file service."""
+
+from __future__ import annotations
+
+from ._helpers import from_dict, list_from_items
+from ._server_service import ServerService, encode_page, put_if
+from .types import (
+    V1MemoryFile,
+    V1MemoryFileDeleteParams,
+    V1MemoryFileGetParams,
+    V1MemoryFileList,
+    V1MemoryFileListParams,
+    V1MemoryFileSearchParams,
+    V1MemoryFileUpsertParams,
+    V1MemoryFileUpsertResult,
+    V1MemoryStore,
+    V1MemoryStoreDeleteParams,
+    V1MemoryStoreGetParams,
+    V1MemoryStoreList,
+    V1MemoryStoreListParams,
+    V1MemoryStoreNewParams,
+    V1MemoryStoreUpdateParams,
+    V1Page,
+)
+
+
+class MemoriesService(ServerService):
+    def create_store(self, params: V1MemoryStoreNewParams) -> V1MemoryStore:
+        if not params.name or not params.alias or not params.description:
+            raise ValueError(
+                "hibot: memory store name, alias, and description are required"
+            )
+        body = {
+            "Name": params.name,
+            "Alias": params.alias,
+            "Description": params.description,
+        }
+        put_if(body, "Access", params.access)
+        put_if(body, "ExtractionPolicy", params.extraction_policy)
+        put_if(body, "QuotaPolicy", params.quota_policy)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("CreateMemoryStore", body)
+        new_id = result.get("ID") if isinstance(result, dict) else None
+        if not new_id:
+            raise ValueError("hibot: create memory store response missing ID")
+        return V1MemoryStore(id=new_id, name=params.name, alias=params.alias)
+
+    def list_stores(
+        self, params: V1MemoryStoreListParams = V1MemoryStoreListParams()
+    ) -> V1MemoryStoreList:
+        body = {}
+        put_if(body, "Keyword", params.keyword)
+        put_if(body, "Page", encode_page(params.page))
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("ListMemoryStores", body)
+        out = V1MemoryStoreList()
+        if isinstance(result, dict):
+            out.items = list_from_items(V1MemoryStore, result)
+            out.page = from_dict(V1Page, result.get("Page"))
+        return out
+
+    def get_store(self, params: V1MemoryStoreGetParams) -> V1MemoryStore:
+        if not params.store_id:
+            raise ValueError("hibot: memory store id is required")
+        body = {"StoreID": params.store_id}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetMemoryStore", body)
+        decoded = from_dict(V1MemoryStore, result) or V1MemoryStore()
+        if not decoded.id:
+            raise ValueError("hibot: get memory store response missing ID")
+        return decoded
+
+    def update_store(self, params: V1MemoryStoreUpdateParams) -> None:
+        if not params.store_id:
+            raise ValueError("hibot: memory store id is required")
+        body = {"StoreID": params.store_id}
+        for key, value in (
+            ("Name", params.name),
+            ("Description", params.description),
+            ("Access", params.access),
+            ("ExtractionPolicy", params.extraction_policy),
+            ("QuotaPolicy", params.quota_policy),
+        ):
+            put_if(body, key, value, allow_empty=True)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        self._action("UpdateMemoryStore", body)
+
+    def delete_store(self, params: V1MemoryStoreDeleteParams) -> None:
+        if not params.store_id:
+            raise ValueError("hibot: memory store id is required")
+        body = {"StoreID": params.store_id}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        self._action("DeleteMemoryStore", body)
+
+    def list_files(self, params: V1MemoryFileListParams) -> V1MemoryFileList:
+        if not params.store_id:
+            raise ValueError("hibot: memory store id is required")
+        body = {"StoreID": params.store_id}
+        put_if(body, "Prefix", params.prefix)
+        put_if(body, "Page", encode_page(params.page))
+        put_if(body, "WorkspaceID", params.workspace_id)
+        return self._file_list("ListMemoryFiles", body)
+
+    def search_files(self, params: V1MemoryFileSearchParams) -> V1MemoryFileList:
+        if not params.store_id or not params.keyword:
+            raise ValueError("hibot: memory store id and keyword are required")
+        body = {"StoreID": params.store_id, "Keyword": params.keyword}
+        put_if(body, "Page", encode_page(params.page))
+        put_if(body, "WorkspaceID", params.workspace_id)
+        return self._file_list("SearchMemoryFiles", body)
+
+    def get_file(self, params: V1MemoryFileGetParams) -> V1MemoryFile:
+        if not params.store_id or not params.path:
+            raise ValueError("hibot: memory store id and path are required")
+        body = {"StoreID": params.store_id, "Path": params.path}
+        put_if(body, "IncludeContent", params.include_content, allow_empty=True)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetMemoryFile", body)
+        decoded = from_dict(V1MemoryFile, result) or V1MemoryFile()
+        if not decoded.id:
+            raise ValueError("hibot: get memory file response missing ID")
+        return decoded
+
+    def upsert_file(self, params: V1MemoryFileUpsertParams) -> V1MemoryFileUpsertResult:
+        if not params.store_id or not params.path:
+            raise ValueError("hibot: memory store id and path are required")
+        body = {
+            "StoreID": params.store_id,
+            "Path": params.path,
+            "Content": params.content,
+        }
+        put_if(body, "BaseSha256", params.base_sha256)
+        put_if(body, "BaseRevision", params.base_revision, allow_empty=True)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("UpsertMemoryFile", body)
+        return from_dict(V1MemoryFileUpsertResult, result) or V1MemoryFileUpsertResult()
+
+    def delete_file(self, params: V1MemoryFileDeleteParams) -> None:
+        if not params.store_id or not params.path:
+            raise ValueError("hibot: memory store id and path are required")
+        body = {"StoreID": params.store_id, "Path": params.path}
+        put_if(body, "BaseSha256", params.base_sha256)
+        put_if(body, "BaseRevision", params.base_revision, allow_empty=True)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        self._action("DeleteMemoryFile", body)
+
+    def _file_list(self, action: str, body: dict) -> V1MemoryFileList:
+        result = self._action(action, body)
+        out = V1MemoryFileList()
+        if isinstance(result, dict):
+            out.items = list_from_items(V1MemoryFile, result)
+            out.page = from_dict(V1Page, result.get("Page"))
+        return out
+
+
+__all__ = ["MemoriesService"]

--- a/libs/hibot/hibot/v1/metrics.py
+++ b/libs/hibot/hibot/v1/metrics.py
@@ -1,0 +1,95 @@
+"""V1 page metrics query service."""
+
+from __future__ import annotations
+
+from ._helpers import from_dict
+from ._server_service import ServerService, put_if
+from .types import (
+    V1MetricAggregatorParams,
+    V1MetricBreakdownParams,
+    V1MetricBreakdownResult,
+    V1MetricFilterParams,
+    V1MetricOverviewParams,
+    V1MetricOverviewResult,
+    V1MetricTopKParams,
+    V1MetricTopKResult,
+    V1MetricTrendParams,
+    V1MetricTrendResult,
+)
+
+
+def _aggregator(params: V1MetricAggregatorParams) -> dict:
+    if not params.start_time or not params.end_time:
+        raise ValueError("hibot: metric start_time and end_time are required")
+    body = {"StartTime": params.start_time, "EndTime": params.end_time}
+    put_if(body, "StepSeconds", params.step_seconds, allow_empty=True)
+    return body
+
+
+def _filter(params: V1MetricFilterParams) -> dict:
+    body = {}
+    for key, value in (
+        ("WorkspaceID", params.workspace_id),
+        ("AgentIDs", params.agent_ids),
+        ("Channels", params.channels),
+        ("Models", params.models),
+        ("Statuses", params.statuses),
+        ("ResponseModes", params.response_modes),
+    ):
+        put_if(body, key, value)
+    return body
+
+
+class MetricsService(ServerService):
+    def overview(self, params: V1MetricOverviewParams) -> V1MetricOverviewResult:
+        body = {
+            "Filter": _filter(params.filter),
+            "Aggregator": _aggregator(params.aggregator),
+        }
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetMetricOverview", body)
+        return from_dict(V1MetricOverviewResult, result) or V1MetricOverviewResult()
+
+    def trend(self, params: V1MetricTrendParams) -> V1MetricTrendResult:
+        if not params.metric:
+            raise ValueError("hibot: metric name is required")
+        body = {
+            "Metric": params.metric,
+            "Filter": _filter(params.filter),
+            "Aggregator": _aggregator(params.aggregator),
+        }
+        put_if(body, "GroupBy", params.group_by)
+        put_if(body, "Statistic", params.statistic)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetMetricTrend", body)
+        return from_dict(V1MetricTrendResult, result) or V1MetricTrendResult()
+
+    def top_k(self, params: V1MetricTopKParams) -> V1MetricTopKResult:
+        if not params.metric or not params.group_by or params.limit <= 0:
+            raise ValueError("hibot: metric, group_by, and positive limit are required")
+        body = {
+            "Metric": params.metric,
+            "GroupBy": params.group_by,
+            "Filter": _filter(params.filter),
+            "Aggregator": _aggregator(params.aggregator),
+            "Limit": params.limit,
+        }
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetMetricTopK", body)
+        return from_dict(V1MetricTopKResult, result) or V1MetricTopKResult()
+
+    def breakdown(self, params: V1MetricBreakdownParams) -> V1MetricBreakdownResult:
+        if not params.metric or not params.group_by:
+            raise ValueError("hibot: metric and group_by are required")
+        body = {
+            "Metric": params.metric,
+            "GroupBy": params.group_by,
+            "Filter": _filter(params.filter),
+            "Aggregator": _aggregator(params.aggregator),
+        }
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetMetricBreakdown", body)
+        return from_dict(V1MetricBreakdownResult, result) or V1MetricBreakdownResult()
+
+
+__all__ = ["MetricsService"]

--- a/libs/hibot/hibot/v1/models.py
+++ b/libs/hibot/hibot/v1/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 from .._request import Action
-from .._version import MODEL_VERSION
+from .._version import SERVER_VERSION
 from ._helpers import list_from_items
 from .types import (
     V1Model,
@@ -28,7 +28,12 @@ class ModelsService:
 
     def _action(self, name: str, body):
         return self._v1.requester.do_action(
-            Action(service=self._v1.services.model, version=MODEL_VERSION, action=name, body=body)
+            Action(
+                service=self._v1.services.server,
+                version=SERVER_VERSION,
+                action=name,
+                body=body,
+            )
         )
 
     def get(self, params: Optional[V1ModelGetParams] = None, **kwargs) -> V1Model:
@@ -38,7 +43,13 @@ class ModelsService:
         if params.id and not ids:
             ids = [params.id]
         if not ids:
-            if not (params.name or params.model_name or params.provider or params.type or params.spec):
+            if not (
+                params.name
+                or params.model_name
+                or params.provider
+                or params.type
+                or params.spec
+            ):
                 raise ValueError(
                     "hibot: model id is required (or provide Name/ModelName/Provider/Type/Spec)"
                 )
@@ -56,13 +67,25 @@ class ModelsService:
         return matched
 
     def _find_by_filter(self, params: V1ModelGetParams) -> V1Model:
-        listing = self.list(name=params.name, workspace_id=params.workspace_id)
-        if not listing.items:
-            raise ValueError("hibot: model not found")
-        matched = self._match(listing.items, params)
-        if matched is None:
-            raise ValueError("hibot: model not found matching filter")
-        return matched
+        page_num = 1
+        page_size = 100
+        while True:
+            listing = self.list(
+                name=params.name,
+                workspace_id=params.workspace_id,
+                page={"PageNum": page_num, "PageSize": page_size},
+            )
+            matched = self._match(listing.items, params)
+            if matched is not None:
+                return matched
+            if not listing.items:
+                break
+            if listing.total is not None and page_num * page_size >= listing.total:
+                break
+            if listing.total is None and len(listing.items) < page_size:
+                break
+            page_num += 1
+        raise ValueError("hibot: model not found matching filter")
 
     @staticmethod
     def _match(items: List[V1Model], params: V1ModelGetParams) -> Optional[V1Model]:
@@ -78,23 +101,41 @@ class ModelsService:
             if params.spec and m.spec != params.spec:
                 continue
             return m
-        if not (params.name or params.model_name or params.provider or params.type or params.spec):
+        if not (
+            params.name
+            or params.model_name
+            or params.provider
+            or params.type
+            or params.spec
+        ):
             return items[0]
         return None
 
-    def list(self, *, name: str = "", workspace_id: str = "", page=None, sort_by: str = "", sort_order: str = "") -> V1ModelList:
+    def list(
+        self,
+        *,
+        name: str = "",
+        workspace_id: str = "",
+        page=None,
+        sort_by: str = "",
+        sort_order: str = "",
+    ) -> V1ModelList:
         body = {}
         if workspace_id:
             body["WorkspaceID"] = workspace_id
         if page is not None:
-            body["Page"] = page if isinstance(page, dict) else {"PageNum": page.page_num, "PageSize": page.page_size}
+            body["Page"] = (
+                page
+                if isinstance(page, dict)
+                else {"PageNum": page.page_num, "PageSize": page.page_size}
+            )
         if sort_by:
             body["SortBy"] = sort_by
         if sort_order:
             body["SortOrder"] = sort_order
         if name:
             body["Filter"] = {"Name": name}
-        result = self._action("ListModel", body)
+        result = self._action("ListModels", body)
         ml = V1ModelList()
         if isinstance(result, dict):
             ml.items = list_from_items(V1Model, result)
@@ -176,17 +217,22 @@ class ModelsService:
         self._action("DeleteModel", body)
 
     def list_providers(self) -> List[str]:
-        result = self._action("ListProvider", {})
+        result = self._action("ListProviders", {})
         if isinstance(result, dict):
             return list(result.get("Providers") or [])
         return []
 
-    def list_model_providers(self, params: V1ModelProviderListParams) -> V1ModelProviderList:
+    def list_model_providers(
+        self, params: V1ModelProviderListParams
+    ) -> V1ModelProviderList:
         body = {}
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         if params.page is not None:
-            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+            body["Page"] = {
+                "PageNum": params.page.page_num,
+                "PageSize": params.page.page_size,
+            }
         if params.sort_by:
             body["SortBy"] = params.sort_by
         if params.sort_order:
@@ -202,23 +248,27 @@ class ModelsService:
             flt["Features"] = list(params.features)
         if flt:
             body["Filter"] = flt
-        result = self._action("ListModelProvider", body)
+        result = self._action("ListModelProviders", body)
         out = V1ModelProviderList()
         if isinstance(result, dict):
             out.items = list_from_items(V1ModelProvider, result, key="Models")
             out.total = result.get("Total")
         return out
 
-    def get_model_provider(self, params: V1ModelProviderGetParams) -> List[V1ModelProvider]:
+    def get_model_provider(
+        self, params: V1ModelProviderGetParams
+    ) -> List[V1ModelProvider]:
         if not params.ids:
             raise ValueError("hibot: provider IDs are required")
         body = {"IDs": list(params.ids)}
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
-        result = self._action("GetProvider", body)
+        result = self._action("GetModelProvider", body)
         return list_from_items(V1ModelProvider, result)
 
-    def get_model_provider_credential_schema(self, params: V1ModelProviderCredentialSchemaParams):
+    def get_model_provider_credential_schema(
+        self, params: V1ModelProviderCredentialSchemaParams
+    ):
         if not params.provider:
             raise ValueError("hibot: provider is required")
         if not params.type:

--- a/libs/hibot/hibot/v1/observations.py
+++ b/libs/hibot/hibot/v1/observations.py
@@ -1,0 +1,53 @@
+"""V1 trace and span observation service."""
+
+from __future__ import annotations
+
+from ._helpers import from_dict
+from ._server_service import ServerService, put_if
+from .types import (
+    V1SpanDetail,
+    V1SpanGetParams,
+    V1SpanList,
+    V1SpanListParams,
+    V1TraceList,
+    V1TraceListParams,
+)
+
+
+class ObservationsService(ServerService):
+    def list_traces(
+        self, params: V1TraceListParams = V1TraceListParams()
+    ) -> V1TraceList:
+        body = {}
+        put_if(body, "ScrollID", params.scroll_id)
+        put_if(body, "PageSize", params.page_size, allow_empty=True)
+        if params.session_id:
+            body["Filter"] = {"SessionID": params.session_id}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        return from_dict(V1TraceList, self._action("ListTraces", body)) or V1TraceList()
+
+    def list_trace_spans(self, params: V1SpanListParams) -> V1SpanList:
+        if not params.trace_id:
+            raise ValueError("hibot: trace id is required")
+        body = {"TraceID": params.trace_id}
+        put_if(body, "ScrollID", params.scroll_id)
+        put_if(body, "PageSize", params.page_size, allow_empty=True)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        return (
+            from_dict(V1SpanList, self._action("ListTraceSpans", body)) or V1SpanList()
+        )
+
+    def get_span_detail(self, params: V1SpanGetParams) -> V1SpanDetail:
+        if not params.trace_id or not params.span_id:
+            raise ValueError("hibot: trace id and span id are required")
+        body = {"TraceID": params.trace_id, "SpanID": params.span_id}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetSpanDetail", body)
+        span = result.get("Span") if isinstance(result, dict) else None
+        decoded = from_dict(V1SpanDetail, span) or V1SpanDetail()
+        if not decoded.span_id:
+            raise ValueError("hibot: get span detail response missing SpanID")
+        return decoded
+
+
+__all__ = ["ObservationsService"]

--- a/libs/hibot/hibot/v1/overview.py
+++ b/libs/hibot/hibot/v1/overview.py
@@ -1,0 +1,17 @@
+"""V1 workspace overview service."""
+
+from __future__ import annotations
+
+from ._helpers import from_dict
+from ._server_service import ServerService, put_if
+from .types import V1Overview
+
+
+class OverviewService(ServerService):
+    def get(self, *, workspace_id: str = "") -> V1Overview:
+        body = {}
+        put_if(body, "WorkspaceID", workspace_id)
+        return from_dict(V1Overview, self._action("GetOverview", body)) or V1Overview()
+
+
+__all__ = ["OverviewService"]

--- a/libs/hibot/hibot/v1/resources.py
+++ b/libs/hibot/hibot/v1/resources.py
@@ -16,11 +16,13 @@ from .types import (
     V1DirectoryNewParams,
     V1DirectoryUpdateParams,
     V1Resource,
+    V1ResourceBatchCreateParams,
     V1ResourceBatchGetParams,
     V1ResourceDeleteParams,
     V1ResourceGetByNameParams,
     V1ResourceList,
     V1ResourceListParams,
+    V1ResourceMoveParams,
     V1ResourceNewParams,
     V1ResourceUpdateParams,
 )
@@ -32,7 +34,12 @@ class _BaseService:
 
     def _action(self, name: str, body):
         return self._v1.requester.do_action(
-            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+            Action(
+                service=self._v1.services.server,
+                version=SERVER_VERSION,
+                action=name,
+                body=body,
+            )
         )
 
 
@@ -47,20 +54,30 @@ class DirectoriesService(_BaseService):
         new_id = result.get("ID") if isinstance(result, dict) else None
         if not new_id:
             raise ValueError("hibot: create directory response missing ID")
-        return V1Directory(id=new_id, name=params.name, workspace_id=params.workspace_id)
+        return V1Directory(
+            id=new_id, name=params.name, workspace_id=params.workspace_id
+        )
 
-    def list(self, params: V1DirectoryListParams = V1DirectoryListParams()) -> V1DirectoryList:
+    def list(
+        self, params: V1DirectoryListParams = V1DirectoryListParams()
+    ) -> V1DirectoryList:
         body = {}
         if params.name:
             body["Name"] = params.name
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         if params.page is not None:
-            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+            body["Page"] = {
+                "PageNum": params.page.page_num,
+                "PageSize": params.page.page_size,
+            }
         result = self._action("ListDirectories", body)
         out = V1DirectoryList()
         if isinstance(result, dict):
             out.items = list_from_items(V1Directory, result)
+            from .types import V1Page
+
+            out.page = from_dict(V1Page, result.get("Page"))
         return out
 
     def update(self, params: V1DirectoryUpdateParams) -> None:
@@ -104,7 +121,9 @@ class ResourcesService(_BaseService):
         if not params.name:
             raise ValueError("hibot: resource Name is required")
         if not params.blob_id:
-            raise ValueError("hibot: resource BlobID is required (call uploads.upload_blob first)")
+            raise ValueError(
+                "hibot: resource BlobID is required (call uploads.upload_blob first)"
+            )
         body = {"Name": params.name, "BlobID": params.blob_id}
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
@@ -121,7 +140,26 @@ class ResourcesService(_BaseService):
             directory_id=params.directory_id,
         )
 
-    def list(self, params: V1ResourceListParams = V1ResourceListParams()) -> V1ResourceList:
+    def batch_create(self, params: V1ResourceBatchCreateParams) -> List[V1Resource]:
+        if not params.items:
+            raise ValueError("hibot: resources are required")
+        items = []
+        for item in params.items:
+            if not item.name or not item.blob_id:
+                raise ValueError("hibot: each resource requires Name and BlobID")
+            encoded = {"Name": item.name, "BlobID": item.blob_id}
+            if item.directory_id:
+                encoded["DirectoryID"] = item.directory_id
+            items.append(encoded)
+        body = {"Items": items}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("BatchCreateResources", body)
+        return list_from_items(V1Resource, result)
+
+    def list(
+        self, params: V1ResourceListParams = V1ResourceListParams()
+    ) -> V1ResourceList:
         body = {}
         if params.directory_id:
             body["DirectoryID"] = params.directory_id
@@ -130,11 +168,17 @@ class ResourcesService(_BaseService):
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         if params.page is not None:
-            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+            body["Page"] = {
+                "PageNum": params.page.page_num,
+                "PageSize": params.page.page_size,
+            }
         result = self._action("ListResources", body)
         out = V1ResourceList()
         if isinstance(result, dict):
             out.items = list_from_items(V1Resource, result)
+            from .types import V1Page
+
+            out.page = from_dict(V1Page, result.get("Page"))
         return out
 
     def update(self, params: V1ResourceUpdateParams) -> None:
@@ -146,6 +190,18 @@ class ResourcesService(_BaseService):
         if params.directory_id is not None:
             body["DirectoryID"] = params.directory_id
         self._action("UpdateResource", body)
+
+    def move(self, params: V1ResourceMoveParams) -> None:
+        if not params.resource_id:
+            raise ValueError("hibot: resource id is required")
+        body = {"ResourceID": params.resource_id}
+        if params.old_directory_id:
+            body["OldDirectoryID"] = params.old_directory_id
+        if params.new_directory_id:
+            body["NewDirectoryID"] = params.new_directory_id
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        self._action("MoveResource", body)
 
     def delete(self, params: V1ResourceDeleteParams) -> None:
         if not params.resource_id:

--- a/libs/hibot/hibot/v1/runs.py
+++ b/libs/hibot/hibot/v1/runs.py
@@ -1,0 +1,36 @@
+"""V1 Runtime read-model service."""
+
+from __future__ import annotations
+
+from typing import List
+
+from ._helpers import from_dict, list_from_items
+from ._server_service import ServerService, put_if
+from .types import V1Run, V1RunGetParams, V1RunListParams
+
+
+class RunsService(ServerService):
+    def list(self, params: V1RunListParams = V1RunListParams()) -> List[V1Run]:
+        body = {}
+        for key, value in (
+            ("AgentID", params.agent_id),
+            ("SessionID", params.session_id),
+            ("Status", params.status),
+            ("WorkspaceID", params.workspace_id),
+        ):
+            put_if(body, key, value)
+        return list_from_items(V1Run, self._action("ListRuns", body))
+
+    def get(self, params: V1RunGetParams) -> V1Run:
+        if not params.run_id:
+            raise ValueError("hibot: run id is required")
+        body = {"RunID": params.run_id}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetRun", body)
+        decoded = from_dict(V1Run, result) or V1Run()
+        if not decoded.id:
+            raise ValueError("hibot: get run response missing ID")
+        return decoded
+
+
+__all__ = ["RunsService"]

--- a/libs/hibot/hibot/v1/runtime_api_keys.py
+++ b/libs/hibot/hibot/v1/runtime_api_keys.py
@@ -1,0 +1,80 @@
+"""V1 Runtime API key service."""
+
+from __future__ import annotations
+
+from typing import List
+
+from ._helpers import from_dict, list_from_items
+from ._server_service import ServerService, put_if
+from .types import (
+    V1RuntimeAPIKey,
+    V1RuntimeAPIKeyCreateResult,
+    V1RuntimeAPIKeyDeleteParams,
+    V1RuntimeAPIKeyGetParams,
+    V1RuntimeAPIKeyListParams,
+    V1RuntimeAPIKeyNewParams,
+    V1RuntimeAPIKeyUpdateParams,
+)
+
+
+class RuntimeAPIKeysService(ServerService):
+    def create(self, params: V1RuntimeAPIKeyNewParams) -> V1RuntimeAPIKeyCreateResult:
+        if not params.agent_id or not params.expired:
+            raise ValueError("hibot: runtime API key agent id and expiry are required")
+        body = {"AgentID": params.agent_id, "Expired": params.expired}
+        put_if(body, "Description", params.description)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("CreateRuntimeAPIKey", body)
+        decoded = from_dict(V1RuntimeAPIKeyCreateResult, result)
+        if decoded is None or not decoded.raw_key:
+            raise ValueError("hibot: create runtime API key response missing RawKey")
+        return decoded
+
+    def list(self, params: V1RuntimeAPIKeyListParams) -> List[V1RuntimeAPIKey]:
+        if not params.agent_id:
+            raise ValueError("hibot: runtime API key agent id is required")
+        body = {"AgentID": params.agent_id}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        return list_from_items(
+            V1RuntimeAPIKey, self._action("ListRuntimeAPIKeys", body)
+        )
+
+    def reveal(self, params: V1RuntimeAPIKeyGetParams) -> str:
+        if not params.agent_id or not params.id:
+            raise ValueError("hibot: runtime API key agent id and id are required")
+        if not params.user_info.user_name or not params.user_info.password:
+            raise ValueError(
+                "hibot: user name and password are required to reveal a key"
+            )
+        body = {
+            "AgentID": params.agent_id,
+            "ID": params.id,
+            "UserInfo": {
+                "UserName": params.user_info.user_name,
+                "Password": params.user_info.password,
+            },
+        }
+        put_if(body, "WorkspaceID", params.workspace_id)
+        result = self._action("GetRuntimeAPIKey", body)
+        raw_key = result.get("RawKey") if isinstance(result, dict) else None
+        if not raw_key:
+            raise ValueError("hibot: get runtime API key response missing RawKey")
+        return raw_key
+
+    def update(self, params: V1RuntimeAPIKeyUpdateParams) -> None:
+        if not params.agent_id or not params.id:
+            raise ValueError("hibot: runtime API key agent id and id are required")
+        body = {"AgentID": params.agent_id, "ID": params.id}
+        put_if(body, "Description", params.description, allow_empty=True)
+        put_if(body, "WorkspaceID", params.workspace_id)
+        self._action("UpdateRuntimeAPIKey", body)
+
+    def delete(self, params: V1RuntimeAPIKeyDeleteParams) -> None:
+        if not params.agent_id or not params.id:
+            raise ValueError("hibot: runtime API key agent id and id are required")
+        body = {"AgentID": params.agent_id, "ID": params.id}
+        put_if(body, "WorkspaceID", params.workspace_id)
+        self._action("DeleteRuntimeAPIKey", body)
+
+
+__all__ = ["RuntimeAPIKeysService"]

--- a/libs/hibot/hibot/v1/sessions.py
+++ b/libs/hibot/hibot/v1/sessions.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
-import secrets
 import threading
 
 from .._request import Action
 from .._response import APIError
-from .._version import CHAT_VERSION, SERVER_VERSION
+from .._version import SERVER_VERSION
 from ._helpers import from_dict
 from .stream import V1SessionChatStream
 from .types import (
-    V1_SESSION_CHAT_EVENT_FAILED,
+    V1ChatApproveParams,
+    V1ChatCancelRunParams,
+    V1ChatCommandResult,
+    V1ChatResumeParams,
     V1Message,
     V1MessageGetParams,
     V1MessageInjectParams,
@@ -19,6 +21,7 @@ from .types import (
     V1MessageListParams,
     V1Session,
     V1SessionArchiveParams,
+    V1SessionBatchGetParams,
     V1SessionChatParams,
     V1SessionDeleteParams,
     V1SessionGetByKeyParams,
@@ -26,17 +29,8 @@ from .types import (
     V1SessionList,
     V1SessionListParams,
     V1SessionNewParams,
+    V1WebChatResumeHint,
 )
-
-
-def _generate_conversation_id() -> str:
-    """生成符合 ``^[A-Za-z0-9_-]{1,64}$`` 的 ConversationID。
-
-    使用 16 字节随机数转 32 位 hex，长度与字符集均严格满足，且各端 SDK 共用
-    同一种生成策略。仅在 webchat 渠道下注入。
-    """
-
-    return secrets.token_hex(16)
 
 
 class SessionsService:
@@ -47,7 +41,12 @@ class SessionsService:
 
     def _action(self, name: str, body):
         return self._v1.requester.do_action(
-            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+            Action(
+                service=self._v1.services.server,
+                version=SERVER_VERSION,
+                action=name,
+                body=body,
+            )
         )
 
     # CRUD --------------------------------------------------------------
@@ -72,12 +71,19 @@ class SessionsService:
                 payload["PeerKind"] = params.peer.peer_kind
             if params.peer.peer_id:
                 payload["PeerID"] = params.peer.peer_id
-        # ConversationID 仅在 webchat 渠道由 SDK 自动生成并透传；其它渠道
-        # 留空，这里直接跳过以避免污染请求体。
-        if payload["Channel"] == "webchat":
-            cid = _generate_conversation_id()
-            if cid:
-                payload["ConversationID"] = cid
+        # For a new WebChat session the server derives identity from the new
+        # SessionID. ConversationID is sent only when the caller explicitly
+        # opts into a stable multi-session identity.
+        for key, value in (
+            ("SessionKey", params.session_key),
+            ("RiskLevel", params.risk_level),
+            ("Config", params.config),
+            ("AuthContext", params.auth_context),
+            ("Metadata", params.metadata),
+            ("ConversationID", params.conversation_id),
+        ):
+            if value not in (None, ""):
+                payload[key] = value
         body["Payload"] = payload
         result = self._action("CreateSession", body)
         session = from_dict(V1Session, result) or V1Session()
@@ -88,7 +94,9 @@ class SessionsService:
             self._session_agents[session.id] = params.agent_id
         return session
 
-    def list(self, params: V1SessionListParams = V1SessionListParams()) -> V1SessionList:
+    def list(
+        self, params: V1SessionListParams = V1SessionListParams()
+    ) -> V1SessionList:
         body = {}
         if params.agent_id:
             body["AgentID"] = params.agent_id
@@ -96,10 +104,17 @@ class SessionsService:
             body["Status"] = params.status
         if params.channel:
             body["Channel"] = params.channel
+        if params.session_keys:
+            body["SessionKeys"] = params.session_keys
+        if params.user_id:
+            body["UserID"] = params.user_id
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         if params.page is not None:
-            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+            body["Page"] = {
+                "PageNum": params.page.page_num,
+                "PageSize": params.page.page_size,
+            }
         result = self._action("ListSessions", body)
         out = V1SessionList()
         if isinstance(result, dict):
@@ -111,6 +126,20 @@ class SessionsService:
                 from .types import V1Page
 
                 out.page = from_dict(V1Page, page)
+        return out
+
+    def batch_get(self, params: V1SessionBatchGetParams) -> V1SessionList:
+        if not params.session_ids:
+            raise ValueError("hibot: session ids are required")
+        body = {"SessionIDs": params.session_ids}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("BatchGetSessions", body)
+        out = V1SessionList()
+        if isinstance(result, dict):
+            from ._helpers import list_from_items
+
+            out.items = list_from_items(V1Session, result)
         return out
 
     def get(self, params: V1SessionGetParams) -> V1Session:
@@ -170,10 +199,17 @@ class SessionsService:
         body = {"SessionID": params.session_id}
         if params.visibility:
             body["Visibility"] = params.visibility
+        if params.display_mode:
+            body["DisplayMode"] = params.display_mode
+        if params.base_message_id:
+            body["BaseMessageID"] = params.base_message_id
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         if params.page is not None:
-            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+            body["Page"] = {
+                "PageNum": params.page.page_num,
+                "PageSize": params.page.page_size,
+            }
         result = self._action("ListMessages", body)
         out = V1MessageList()
         if isinstance(result, dict):
@@ -185,6 +221,7 @@ class SessionsService:
                 from .types import V1Page
 
                 out.page = from_dict(V1Page, page)
+            out.resume_hint = from_dict(V1WebChatResumeHint, result.get("ResumeHint"))
         return out
 
     def get_message(self, params: V1MessageGetParams) -> V1Message:
@@ -207,6 +244,12 @@ class SessionsService:
             payload["Role"] = params.role
         if params.content:
             payload["Content"] = params.content
+        if params.tool_calls is not None:
+            payload["ToolCalls"] = params.tool_calls
+        if params.tool_result is not None:
+            payload["ToolResult"] = params.tool_result
+        if params.metadata is not None:
+            payload["Metadata"] = params.metadata
         body = {"SessionID": params.session_id, "Payload": payload}
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
@@ -219,18 +262,92 @@ class SessionsService:
     # Chat --------------------------------------------------------------
 
     def chat(self, session_id: str, params: V1SessionChatParams) -> V1Message:
-        # 非流式 Chat 自动 set-all 审批，避免单回合中断在审批环节。
-        with self._chat_streaming(session_id, params, auto_approve_all=True) as stream:
-            for event in stream:
-                if event.type == V1_SESSION_CHAT_EVENT_FAILED:
-                    msg = event.error.message or event.error.code or "unknown error"
-                    raise APIError(status_code=0, message=f"hibot: chat failed: {msg}")
-            if stream.err is not None:
-                raise stream.err
-            return stream.final_message()
+        body = self._chat_body(session_id, params)
+        body["Approve"] = "all"
+        body["Stream"] = False
+        result = self._v1.requester.do_long_action(
+            Action(
+                service=self._v1.services.server,
+                version=SERVER_VERSION,
+                action="Chat",
+                body=body,
+            )
+        )
+        message = V1Message(
+            session_id=session_id,
+            role="assistant",
+            content=result.get("Message", "") if isinstance(result, dict) else "",
+            token_count=result.get("TokenCount") if isinstance(result, dict) else None,
+        )
+        if isinstance(result, dict) and isinstance(result.get("Files"), list):
+            from ._helpers import list_from_items
+            from .types import V1MessageFile
 
-    def chat_streaming(self, session_id: str, params: V1SessionChatParams) -> V1SessionChatStream:
+            message.files = list_from_items(V1MessageFile, {"Items": result["Files"]})
+        return message
+
+    def chat_streaming(
+        self, session_id: str, params: V1SessionChatParams
+    ) -> V1SessionChatStream:
         return self._chat_streaming(session_id, params, auto_approve_all=False)
+
+    def chat_resume(self, params: V1ChatResumeParams) -> V1SessionChatStream:
+        if not params.session_id:
+            return V1SessionChatStream(
+                error=ValueError("hibot: session id is required")
+            )
+        agent_id = self._resolve_agent_id(
+            params.session_id,
+            V1SessionChatParams(
+                agent_id=params.agent_id,
+                workspace_id=params.workspace_id,
+            ),
+        )
+        body = {"SessionID": params.session_id, "AgentID": agent_id}
+        for key, value in (
+            ("RunID", params.run_id),
+            ("RequestID", params.request_id),
+            ("LastEventID", params.last_event_id),
+            ("Approve", params.approve),
+            ("WorkspaceID", params.workspace_id),
+        ):
+            if value:
+                body[key] = value
+        return self._open_stream("ChatResume", body)
+
+    def approve(self, params: V1ChatApproveParams) -> V1ChatCommandResult:
+        if not all(
+            (
+                params.session_id,
+                params.run_id,
+                params.approval_request_id,
+                params.choice_id,
+            )
+        ):
+            raise ValueError(
+                "hibot: session id, run id, approval request id, and choice id are required"
+            )
+        body = {
+            "SessionID": params.session_id,
+            "RunID": params.run_id,
+            "ApprovalRequestID": params.approval_request_id,
+            "ChoiceID": params.choice_id,
+        }
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("Approve", body)
+        return from_dict(V1ChatCommandResult, result) or V1ChatCommandResult()
+
+    def cancel_run(self, params: V1ChatCancelRunParams) -> V1ChatCommandResult:
+        if not params.session_id or not params.run_id:
+            raise ValueError("hibot: session id and run id are required")
+        body = {"SessionID": params.session_id, "RunID": params.run_id}
+        if params.reason:
+            body["Reason"] = params.reason
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("CancelRun", body)
+        return from_dict(V1ChatCommandResult, result) or V1ChatCommandResult()
 
     def _chat_streaming(
         self,
@@ -239,10 +356,19 @@ class SessionsService:
         auto_approve_all: bool,
     ) -> V1SessionChatStream:
         if not session_id:
-            return V1SessionChatStream(error=ValueError("hibot: session id is required"))
-        agent_id = params.agent_id
-        if not agent_id:
-            agent_id = self._agent_id_for_session(session_id)
+            return V1SessionChatStream(
+                error=ValueError("hibot: session id is required")
+            )
+        body = self._chat_body(session_id, params)
+        if auto_approve_all:
+            body["Approve"] = "all"
+        body["Stream"] = True
+        return self._open_stream("Chat", body)
+
+    def _chat_body(self, session_id: str, params: V1SessionChatParams) -> dict:
+        if not session_id:
+            raise ValueError("hibot: session id is required")
+        agent_id = self._resolve_agent_id(session_id, params)
         body = {
             "SessionID": session_id,
             "AgentID": agent_id,
@@ -268,14 +394,19 @@ class SessionsService:
             body["WorkspaceID"] = params.workspace_id
         if params.client_message_id:
             body["ClientMessageID"] = params.client_message_id
-        if auto_approve_all:
-            body["Approve"] = "all"
+        if params.conversation_id:
+            body["ConversationID"] = params.conversation_id
+        return body
+
+    # internal ----------------------------------------------------------
+
+    def _open_stream(self, action: str, body: dict) -> V1SessionChatStream:
         try:
             resp = self._v1.requester.stream_action(
                 Action(
-                    service=self._v1.services.gateway,
-                    version=CHAT_VERSION,
-                    action="Chat",
+                    service=self._v1.services.server,
+                    version=SERVER_VERSION,
+                    action=action,
                     body=body,
                 )
             )
@@ -287,15 +418,42 @@ class SessionsService:
             finally:
                 resp.close()
             return V1SessionChatStream(
-                error=APIError(status_code=resp.status_code, message=body_bytes.decode("utf-8", "replace"))
+                error=APIError(
+                    status_code=resp.status_code,
+                    message=body_bytes.decode("utf-8", "replace"),
+                )
             )
         return V1SessionChatStream(resp=resp)
-
-    # internal ----------------------------------------------------------
 
     def _agent_id_for_session(self, session_id: str) -> str:
         with self._lock:
             return self._session_agents.get(session_id, "")
+
+    def _resolve_agent_id(self, session_id: str, params: V1SessionChatParams) -> str:
+        if params.agent_id:
+            return params.agent_id
+        cached = self._agent_id_for_session(session_id)
+        if cached:
+            return cached
+        try:
+            session = self.get(
+                V1SessionGetParams(
+                    session_id=session_id,
+                    workspace_id=params.workspace_id,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise ValueError(
+                f"hibot: resolve agent id for session {session_id!r}: {exc}"
+            ) from exc
+        if not session.agent_id:
+            raise ValueError(
+                f"hibot: session {session_id!r} response missing AgentID; "
+                "pass V1SessionChatParams.agent_id explicitly"
+            )
+        with self._lock:
+            self._session_agents[session_id] = session.agent_id
+        return session.agent_id
 
 
 __all__ = ["SessionsService"]

--- a/libs/hibot/hibot/v1/skills.py
+++ b/libs/hibot/hibot/v1/skills.py
@@ -8,12 +8,21 @@ from .._request import Action
 from .._version import SERVER_VERSION
 from ._helpers import from_dict, list_from_items
 from .types import (
+    V1ArkSkillHubGetParams,
+    V1ArkSkillHubImportParams,
+    V1ArkSkillHubListParams,
+    V1ArkSkillHubSkill,
+    V1ArkSkillHubSkillList,
+    V1Page,
     V1Skill,
+    V1SkillBatchGetParams,
     V1SkillCredentialInputParams,
     V1SkillDeleteParams,
     V1SkillGetParams,
     V1SkillListParams,
     V1SkillNewParams,
+    V1SkillParseParams,
+    V1SkillParseResult,
     V1SkillResolveVersionParams,
     V1SkillUpdateParams,
     V1SkillVersion,
@@ -58,7 +67,12 @@ class SkillsService:
 
     def _action(self, name: str, body):
         return self._v1.requester.do_action(
-            Action(service=self._v1.services.server, version=SERVER_VERSION, action=name, body=body)
+            Action(
+                service=self._v1.services.server,
+                version=SERVER_VERSION,
+                action=name,
+                body=body,
+            )
         )
 
     def create(self, params: V1SkillNewParams) -> V1SkillVersion:
@@ -77,7 +91,9 @@ class SkillsService:
         if params.slug_id:
             body["SlugID"] = params.slug_id
         if params.credential_config is not None:
-            body["CredentialConfig"] = _credential_config_to_dict(params.credential_config)
+            body["CredentialConfig"] = _credential_config_to_dict(
+                params.credential_config
+            )
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
         result = self._action("CreateSkill", body)
@@ -91,6 +107,59 @@ class SkillsService:
             version=params.version,
         )
 
+    def parse(self, params: V1SkillParseParams) -> V1SkillParseResult:
+        if not params.blob_id:
+            raise ValueError("hibot: skill blob id is required")
+        body = {"BlobID": params.blob_id}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("ParseSkill", body)
+        return from_dict(V1SkillParseResult, result) or V1SkillParseResult()
+
+    def list_ark_skill_hub(
+        self, params: V1ArkSkillHubListParams = V1ArkSkillHubListParams()
+    ) -> V1ArkSkillHubSkillList:
+        body = {}
+        if params.keyword:
+            body["Keyword"] = params.keyword
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        if params.page is not None:
+            body["Page"] = {
+                "PageNum": params.page.page_num,
+                "PageSize": params.page.page_size,
+            }
+        result = self._action("ListArkSkillHubSkills", body)
+        out = V1ArkSkillHubSkillList()
+        if isinstance(result, dict):
+            out.items = list_from_items(V1ArkSkillHubSkill, result)
+            out.page = from_dict(V1Page, result.get("Page"))
+        return out
+
+    def get_ark_skill_hub(self, params: V1ArkSkillHubGetParams) -> V1ArkSkillHubSkill:
+        if not params.slug:
+            raise ValueError("hibot: Ark Skill Hub slug is required")
+        body = {"Slug": params.slug}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("GetArkSkillHubSkill", body)
+        skill = result.get("Skill") if isinstance(result, dict) else None
+        decoded = from_dict(V1ArkSkillHubSkill, skill) or V1ArkSkillHubSkill()
+        if not decoded.slug:
+            raise ValueError("hibot: get Ark Skill Hub skill response missing Slug")
+        return decoded
+
+    def import_ark_skill_hub(
+        self, params: V1ArkSkillHubImportParams
+    ) -> V1SkillParseResult:
+        if not params.slug:
+            raise ValueError("hibot: Ark Skill Hub slug is required")
+        body = {"Slug": params.slug}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("ImportArkSkillHubSkill", body)
+        return from_dict(V1SkillParseResult, result) or V1SkillParseResult()
+
     def list(self, params: V1SkillListParams = V1SkillListParams()) -> List[V1Skill]:
         body = {}
         if params.keyword:
@@ -103,7 +172,21 @@ class SkillsService:
             body["SlugID"] = params.slug_id
         if params.workspace_id:
             body["WorkspaceID"] = params.workspace_id
+        if params.page is not None:
+            body["Page"] = {
+                "PageNum": params.page.page_num,
+                "PageSize": params.page.page_size,
+            }
         result = self._action("ListSkills", body)
+        return list_from_items(V1Skill, result)
+
+    def batch_get(self, params: V1SkillBatchGetParams) -> List[V1Skill]:
+        if not params.ids:
+            raise ValueError("hibot: skill version IDs are required")
+        body = {"IDs": list(params.ids)}
+        if params.workspace_id:
+            body["WorkspaceID"] = params.workspace_id
+        result = self._action("BatchGetSkills", body)
         return list_from_items(V1Skill, result)
 
     def get(self, params: V1SkillGetParams) -> V1Skill:
@@ -140,8 +223,12 @@ class SkillsService:
             body["Description"] = params.description
         if params.source is not None:
             body["Source"] = params.source
-        if params.artifact_id is not None:
-            body["ArtifactID"] = params.artifact_id
+        blob_id = params.blob_id
+        if blob_id is None:
+            # Compatibility for the old SDK field; the current server accepts BlobID.
+            blob_id = params.artifact_id
+        if blob_id is not None:
+            body["BlobID"] = blob_id
         if params.enabled is not None:
             body["Enabled"] = params.enabled
         if params.new_version is not None:
@@ -149,7 +236,9 @@ class SkillsService:
         if params.slug_id is not None:
             body["SlugID"] = params.slug_id
         if params.credential_config is not None:
-            body["CredentialConfig"] = _credential_config_to_dict(params.credential_config)
+            body["CredentialConfig"] = _credential_config_to_dict(
+                params.credential_config
+            )
         self._action("UpdateSkill", body)
 
     def delete(self, params: V1SkillDeleteParams) -> None:
@@ -177,13 +266,18 @@ class SkillsService:
         if params.sort_order:
             body["SortOrder"] = params.sort_order
         if params.page is not None:
-            body["Page"] = {"PageNum": params.page.page_num, "PageSize": params.page.page_size}
+            body["Page"] = {
+                "PageNum": params.page.page_num,
+                "PageSize": params.page.page_size,
+            }
         result = self._action("ListSkillVersions", body)
         return list_from_items(V1SkillVersion, result)
 
     def resolve_version(self, params: V1SkillResolveVersionParams) -> V1SkillVersion:
         if params.id:
-            return V1SkillVersion(id=params.id, name=params.name, constraint=params.constraint)
+            return V1SkillVersion(
+                id=params.id, name=params.name, constraint=params.constraint
+            )
         skill_id = self._resolve_skill_id(params)
         body = {"SkillID": skill_id}
         if params.workspace_id:

--- a/libs/hibot/hibot/v1/stream.py
+++ b/libs/hibot/hibot/v1/stream.py
@@ -20,7 +20,7 @@ from .types import (
     V1SessionTextDelta,
 )
 
-# Compat event names emitted by gateway legacy delivery + private Hermes runtime.
+# Compat event names emitted by legacy delivery + private Hermes runtime.
 _MESSAGE_CHUNK_COMPAT = "message.chunk"
 _MESSAGE_COMPLETED_COMPAT = "message.completed"
 _MESSAGE_FAILED_COMPAT = "message.failed"
@@ -66,7 +66,9 @@ def _first_key(payload: dict, *keys: str):
 
 
 def decode_chat_event(event_name: str, data: str) -> V1SessionChatEvent:
-    event = V1SessionChatEvent(type=normalize_chat_event_name(event_name), raw_data=data or "")
+    event = V1SessionChatEvent(
+        type=normalize_chat_event_name(event_name), raw_data=data or ""
+    )
     if not data:
         return event
     try:
@@ -102,7 +104,9 @@ def decode_chat_event(event_name: str, data: str) -> V1SessionChatEvent:
     if isinstance(err, dict):
         code = err.get("code") or err.get("Code") or ""
         message = err.get("message") or err.get("Message") or ""
-        event.error = V1SessionChatError(code=str(code or ""), message=str(message or ""))
+        event.error = V1SessionChatError(
+            code=str(code or ""), message=str(message or "")
+        )
     elif isinstance(err, str):
         event.error = V1SessionChatError(message=err)
 
@@ -117,6 +121,14 @@ def decode_chat_event(event_name: str, data: str) -> V1SessionChatEvent:
             event.message = msg
     elif isinstance(message_raw, str) and not event.error.message:
         event.error.message = message_raw
+
+    # hibot-server emits run_failed with the public failure reason in Content
+    # rather than Error/Message. Preserve that reason on the typed error so
+    # callers do not need to decode raw_data to diagnose a failed run.
+    if event.type == V1_SESSION_CHAT_EVENT_FAILED and not event.error.message:
+        content = _first_key(payload, "content", "Content")
+        if isinstance(content, str):
+            event.error.message = content
 
     if event.type == V1_SESSION_CHAT_EVENT_COMPLETED and event.message is None:
         msg = V1Message()

--- a/libs/hibot/hibot/v1/types.py
+++ b/libs/hibot/hibot/v1/types.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 
 # ---------------- Constants (sync with go/hibot/v1/types.go) ----------------
 
-V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO = "doubao-seed-2.0-pro-260215"
+V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO = "doubao-seed-2-0-pro-260215"
 V1_RESOURCE_TYPE_DOCUMENT_COLLECTION = "document_collection"
 V1_MCP_TRANSPORT_STREAMABLE_HTTP = "streamable_http"
 
@@ -32,6 +32,7 @@ V1_SESSION_CHAT_EVENT_TOOL_COMPLETE = "tool_complete"
 
 
 # ---------------- Helpers ----------------
+
 
 def _from_dict(cls, data):
     """Construct a dataclass instance from a server-side dict, ignoring extras."""
@@ -58,6 +59,7 @@ def _f(json_name: str):
 
 # ---------------- Result types ----------------
 
+
 @dataclass
 class V1Page:
     page_num: Optional[int] = field(default=None, metadata={"json": "PageNum"})
@@ -81,10 +83,21 @@ class V1Environment:
     memory_limit: Optional[str] = field(default=None, metadata={"json": "MemoryLimit"})
     pvc_size: Optional[str] = field(default=None, metadata={"json": "PVCSize"})
     data_path: Optional[str] = field(default=None, metadata={"json": "DataPath"})
+    spec_code: Optional[str] = field(default=None, metadata={"json": "SpecCode"})
     created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
     updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
     created_by: Optional[str] = field(default=None, metadata={"json": "CreatedBy"})
     updated_by: Optional[str] = field(default=None, metadata={"json": "UpdatedBy"})
+
+
+@dataclass
+class V1WorkspaceSpec:
+    spec_code: Optional[str] = field(default=None, metadata={"json": "SpecCode"})
+    display_name: Optional[str] = field(default=None, metadata={"json": "DisplayName"})
+    cpu: Optional[str] = field(default=None, metadata={"json": "Cpu"})
+    memory: Optional[str] = field(default=None, metadata={"json": "Memory"})
+    storage: Optional[str] = field(default=None, metadata={"json": "Storage"})
+    is_default: Optional[bool] = field(default=None, metadata={"json": "IsDefault"})
 
 
 @dataclass
@@ -97,10 +110,16 @@ class V1Model:
     model_name: Optional[str] = field(default=None, metadata={"json": "ModelName"})
     description: Optional[str] = field(default=None, metadata={"json": "Description"})
     status: Optional[str] = field(default=None, metadata={"json": "Status"})
-    features_config: Optional[Any] = field(default=None, metadata={"json": "FeaturesConfig"})
+    features_config: Optional[Any] = field(
+        default=None, metadata={"json": "FeaturesConfig"}
+    )
     property: Optional[Any] = field(default=None, metadata={"json": "Property"})
-    credential_schema: Optional[Any] = field(default=None, metadata={"json": "CredentialSchema"})
-    credential: Optional[Dict[str, str]] = field(default=None, metadata={"json": "Credential"})
+    credential_schema: Optional[Any] = field(
+        default=None, metadata={"json": "CredentialSchema"}
+    )
+    credential: Optional[Dict[str, str]] = field(
+        default=None, metadata={"json": "Credential"}
+    )
     create_time: Optional[str] = field(default=None, metadata={"json": "CreateTime"})
     update_time: Optional[str] = field(default=None, metadata={"json": "UpdateTime"})
 
@@ -117,14 +136,20 @@ class V1ModelProvider:
     type: Optional[str] = field(default=None, metadata={"json": "Type"})
     provider: Optional[str] = field(default=None, metadata={"json": "Provider"})
     model_name: Optional[str] = field(default=None, metadata={"json": "ModelName"})
-    features_config: Optional[Any] = field(default=None, metadata={"json": "FeaturesConfig"})
+    features_config: Optional[Any] = field(
+        default=None, metadata={"json": "FeaturesConfig"}
+    )
     property: Optional[Any] = field(default=None, metadata={"json": "Property"})
-    credential_schema: Optional[Any] = field(default=None, metadata={"json": "CredentialSchema"})
+    credential_schema: Optional[Any] = field(
+        default=None, metadata={"json": "CredentialSchema"}
+    )
 
 
 @dataclass
 class V1ModelProviderList:
-    items: List[V1ModelProvider] = field(default_factory=list, metadata={"json": "Models"})
+    items: List[V1ModelProvider] = field(
+        default_factory=list, metadata={"json": "Models"}
+    )
     total: Optional[int] = field(default=None, metadata={"json": "Total"})
 
 
@@ -149,6 +174,8 @@ class V1Resource:
     directory_id: Optional[str] = field(default=None, metadata={"json": "DirectoryID"})
     created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
     updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+    created_by: Optional[str] = field(default=None, metadata={"json": "CreatedBy"})
+    updated_by: Optional[str] = field(default=None, metadata={"json": "UpdatedBy"})
 
 
 @dataclass
@@ -163,7 +190,12 @@ class V1Directory:
     name: Optional[str] = field(default=None, metadata={"json": "Name"})
     workspace_id: Optional[str] = field(default=None, metadata={"json": "WorkspaceID"})
     created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
-    resource_count: Optional[int] = field(default=None, metadata={"json": "ResourceCount"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+    created_by: Optional[str] = field(default=None, metadata={"json": "CreatedBy"})
+    updated_by: Optional[str] = field(default=None, metadata={"json": "UpdatedBy"})
+    resource_count: Optional[int] = field(
+        default=None, metadata={"json": "ResourceCount"}
+    )
 
 
 @dataclass
@@ -179,18 +211,30 @@ class V1MCP:
     description: Optional[str] = field(default=None, metadata={"json": "Description"})
     transport: Optional[str] = field(default=None, metadata={"json": "Transport"})
     endpoint: Optional[str] = field(default=None, metadata={"json": "URL"})
-    headers: Optional[Dict[str, str]] = field(default=None, metadata={"json": "Headers"})
+    headers: Optional[Dict[str, str]] = field(
+        default=None, metadata={"json": "Headers"}
+    )
     env: Optional[Dict[str, str]] = field(default=None, metadata={"json": "Env"})
     command: Optional[str] = field(default=None, metadata={"json": "Command"})
     args: Optional[List[str]] = field(default=None, metadata={"json": "Args"})
     auth_type: Optional[str] = field(default=None, metadata={"json": "AuthType"})
-    tool_allowlist: Optional[List[str]] = field(default=None, metadata={"json": "ToolAllowlist"})
-    tool_denylist: Optional[List[str]] = field(default=None, metadata={"json": "ToolDenylist"})
+    credential_provider_id: Optional[str] = field(
+        default=None, metadata={"json": "CredentialProviderID"}
+    )
+    tool_allowlist: Optional[List[str]] = field(
+        default=None, metadata={"json": "ToolAllowlist"}
+    )
+    tool_denylist: Optional[List[str]] = field(
+        default=None, metadata={"json": "ToolDenylist"}
+    )
     tool_prefix: Optional[str] = field(default=None, metadata={"json": "ToolPrefix"})
     timeout: Optional[int] = field(default=None, metadata={"json": "Timeout"})
     status: Optional[str] = field(default=None, metadata={"json": "Status"})
     source: Optional[str] = field(default=None, metadata={"json": "Source"})
     created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+    agent_ids: Optional[List[str]] = field(default=None, metadata={"json": "AgentIDs"})
+    credential: Optional[Any] = field(default=None, metadata={"json": "Credential"})
 
 
 @dataclass
@@ -219,6 +263,11 @@ class V1Skill:
     enabled: Optional[bool] = field(default=None, metadata={"json": "Enabled"})
     slug_id: Optional[str] = field(default=None, metadata={"json": "SlugID"})
     created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+    credential_provider_id: Optional[str] = field(
+        default=None, metadata={"json": "CredentialProviderID"}
+    )
+    credential: Optional[Any] = field(default=None, metadata={"json": "Credential"})
 
 
 @dataclass
@@ -237,6 +286,40 @@ class V1SkillVersion:
 
 
 @dataclass
+class V1SkillParseResult:
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    blob_id: Optional[str] = field(default=None, metadata={"json": "BlobID"})
+
+
+@dataclass
+class V1ArkSkillHubSkill:
+    slug: Optional[str] = field(default=None, metadata={"json": "Slug"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    namespace: Optional[str] = field(default=None, metadata={"json": "Namespace"})
+    tags: Optional[List[str]] = field(default=None, metadata={"json": "Tags"})
+    banned: Optional[bool] = field(default=None, metadata={"json": "Banned"})
+    source_type: Optional[str] = field(default=None, metadata={"json": "SourceType"})
+    source_repo: Optional[str] = field(default=None, metadata={"json": "SourceRepo"})
+    verify: Optional[bool] = field(default=None, metadata={"json": "Verify"})
+    path: Optional[str] = field(default=None, metadata={"json": "Path"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+    skill_markdown: Optional[str] = field(
+        default=None, metadata={"json": "SkillMarkdown"}
+    )
+
+
+@dataclass
+class V1ArkSkillHubSkillList:
+    items: List[V1ArkSkillHubSkill] = field(
+        default_factory=list, metadata={"json": "Items"}
+    )
+    page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
+
+
+@dataclass
 class V1AgentSkillBinding:
     id: Optional[str] = field(default=None, metadata={"json": "ID"})
     enabled: Optional[bool] = field(default=None, metadata={"json": "Enabled"})
@@ -246,8 +329,40 @@ class V1AgentSkillBinding:
 class V1AgentMCPBinding:
     id: Optional[str] = field(default=None, metadata={"json": "ID"})
     enabled: Optional[bool] = field(default=None, metadata={"json": "Enabled"})
-    tool_allowlist: Optional[List[str]] = field(default=None, metadata={"json": "ToolAllowlist"})
-    tool_denylist: Optional[List[str]] = field(default=None, metadata={"json": "ToolDenylist"})
+    tool_allowlist: Optional[List[str]] = field(
+        default=None, metadata={"json": "ToolAllowlist"}
+    )
+    tool_denylist: Optional[List[str]] = field(
+        default=None, metadata={"json": "ToolDenylist"}
+    )
+
+
+@dataclass
+class V1AgentRuntimeInstanceStatus:
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+    ready: Optional[bool] = field(default=None, metadata={"json": "Ready"})
+    reason: Optional[str] = field(default=None, metadata={"json": "Reason"})
+    message: Optional[str] = field(default=None, metadata={"json": "Message"})
+
+
+@dataclass
+class V1AgentRuntimeStatus:
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+    ready: Optional[bool] = field(default=None, metadata={"json": "Ready"})
+    reason: Optional[str] = field(default=None, metadata={"json": "Reason"})
+    message: Optional[str] = field(default=None, metadata={"json": "Message"})
+    replicas: Optional[int] = field(default=None, metadata={"json": "Replicas"})
+    ready_replicas: Optional[int] = field(
+        default=None, metadata={"json": "ReadyReplicas"}
+    )
+    desired_replicas: Optional[int] = field(
+        default=None, metadata={"json": "DesiredReplicas"}
+    )
+    instances: Optional[List[V1AgentRuntimeInstanceStatus]] = field(
+        default=None, metadata={"json": "Instances"}
+    )
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
 
 
 @dataclass
@@ -258,12 +373,52 @@ class V1Agent:
     description: Optional[str] = field(default=None, metadata={"json": "Description"})
     model_id: Optional[str] = field(default=None, metadata={"json": "ModelID"})
     env_id: Optional[str] = field(default=None, metadata={"json": "EnvID"})
-    system_prompt: Optional[str] = field(default=None, metadata={"json": "SystemPrompt"})
-    skills: Optional[List[V1AgentSkillBinding]] = field(default=None, metadata={"json": "Skills"})
-    mcps: Optional[List[V1AgentMCPBinding]] = field(default=None, metadata={"json": "MCPs"})
-    resource_ids: Optional[List[str]] = field(default=None, metadata={"json": "ResourceIDs"})
+    system_prompt: Optional[str] = field(
+        default=None, metadata={"json": "SystemPrompt"}
+    )
+    skills: Optional[List[V1AgentSkillBinding]] = field(
+        default=None, metadata={"json": "Skills"}
+    )
+    mcps: Optional[List[V1AgentMCPBinding]] = field(
+        default=None, metadata={"json": "MCPs"}
+    )
+    resource_ids: Optional[List[str]] = field(
+        default=None, metadata={"json": "ResourceIDs"}
+    )
     created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
     updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+    created_by: Optional[str] = field(default=None, metadata={"json": "CreatedBy"})
+    updated_by: Optional[str] = field(default=None, metadata={"json": "UpdatedBy"})
+    channels: Optional[List[Any]] = field(default=None, metadata={"json": "Channels"})
+    config: Optional[Any] = field(default=None, metadata={"json": "Config"})
+    runtime_status: Optional[V1AgentRuntimeStatus] = field(
+        default=None, metadata={"json": "RuntimeStatus"}
+    )
+    session_count: Optional[int] = field(
+        default=None, metadata={"json": "SessionCount"}
+    )
+    metadata: Optional[Dict[str, str]] = field(
+        default=None, metadata={"json": "Metadata"}
+    )
+    memory_stores: Optional[List[Any]] = field(
+        default=None, metadata={"json": "MemoryStores"}
+    )
+    effective_channel_count: Optional[int] = field(
+        default=None, metadata={"json": "EffectiveChannelCount"}
+    )
+    icon: Optional[str] = field(default=None, metadata={"json": "Icon"})
+    api_protocol_type: Optional[str] = field(
+        default=None, metadata={"json": "ApiProtocolType"}
+    )
+    model_interactive_mode: Optional[str] = field(
+        default=None, metadata={"json": "ModelInteractiveMode"}
+    )
+    allow_responses_api: Optional[bool] = field(
+        default=None, metadata={"json": "AllowResponsesAPI"}
+    )
+    egress_credentials: Optional[List[Any]] = field(
+        default=None, metadata={"json": "EgressCredentials"}
+    )
 
 
 @dataclass
@@ -276,13 +431,23 @@ class V1Session:
     peer_kind: Optional[str] = field(default=None, metadata={"json": "PeerKind"})
     peer_id: Optional[str] = field(default=None, metadata={"json": "PeerID"})
     risk_level: Optional[str] = field(default=None, metadata={"json": "RiskLevel"})
-    message_count: Optional[int] = field(default=None, metadata={"json": "MessageCount"})
-    last_message_at: Optional[str] = field(default=None, metadata={"json": "LastMessageAt"})
-    last_message_content: Optional[str] = field(default=None, metadata={"json": "LastMessageContent"})
+    config: Optional[Any] = field(default=None, metadata={"json": "Config"})
+    auth_context: Optional[Any] = field(default=None, metadata={"json": "AuthContext"})
+    message_count: Optional[int] = field(
+        default=None, metadata={"json": "MessageCount"}
+    )
+    last_message_at: Optional[str] = field(
+        default=None, metadata={"json": "LastMessageAt"}
+    )
+    last_message_content: Optional[str] = field(
+        default=None, metadata={"json": "LastMessageContent"}
+    )
     summary: Optional[str] = field(default=None, metadata={"json": "Summary"})
+    metadata: Optional[Any] = field(default=None, metadata={"json": "Metadata"})
     created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
     updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
     archived_at: Optional[str] = field(default=None, metadata={"json": "ArchivedAt"})
+    deleted_at: Optional[str] = field(default=None, metadata={"json": "DeletedAt"})
 
 
 @dataclass
@@ -291,6 +456,10 @@ class V1MessageFile:
     name: Optional[str] = field(default=None, metadata={"json": "Name"})
     content_type: Optional[str] = field(default=None, metadata={"json": "ContentType"})
     url: Optional[str] = field(default=None, metadata={"json": "URL"})
+    uri: Optional[str] = field(default=None, metadata={"json": "URI"})
+    storage_path: Optional[str] = field(default=None, metadata={"json": "StoragePath"})
+    size_bytes: Optional[int] = field(default=None, metadata={"json": "SizeBytes"})
+    # Chat request compatibility; persisted MessageFile responses use URI/storage fields.
     blob_id: Optional[str] = field(default=None, metadata={"json": "BlobID"})
 
 
@@ -301,15 +470,41 @@ class V1Message:
     run_id: Optional[str] = field(default=None, metadata={"json": "RunID"})
     role: Optional[str] = field(default=None, metadata={"json": "Role"})
     content: Optional[str] = field(default=None, metadata={"json": "Content"})
+    tool_calls: Optional[Any] = field(default=None, metadata={"json": "ToolCalls"})
+    tool_result: Optional[Any] = field(default=None, metadata={"json": "ToolResult"})
+    metadata: Optional[Any] = field(default=None, metadata={"json": "Metadata"})
     visibility: Optional[str] = field(default=None, metadata={"json": "Visibility"})
     created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
-    files: Optional[List[V1MessageFile]] = field(default=None, metadata={"json": "Files"})
+    files: Optional[List[V1MessageFile]] = field(
+        default=None, metadata={"json": "Files"}
+    )
+    event_type: Optional[str] = field(default=None, metadata={"json": "EventType"})
+    payload: Optional[Any] = field(default=None, metadata={"json": "Payload"})
+    sequence: Optional[int] = field(default=None, metadata={"json": "Sequence"})
+    payload_json: Optional[str] = field(default=None, metadata={"json": "PayloadJSON"})
+    token_count: Optional[int] = field(default=None, metadata={"json": "TokenCount"})
+    trace_id: Optional[str] = field(default=None, metadata={"json": "TraceID"})
 
 
 @dataclass
 class V1MessageList:
     items: List[V1Message] = field(default_factory=list, metadata={"json": "Items"})
     page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
+    resume_hint: Optional["V1WebChatResumeHint"] = field(
+        default=None, metadata={"json": "ResumeHint"}
+    )
+
+
+@dataclass
+class V1WebChatResumeHint:
+    run_id: Optional[str] = field(default=None, metadata={"json": "RunID"})
+    request_id: Optional[str] = field(default=None, metadata={"json": "RequestID"})
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+
+
+@dataclass
+class V1ChatCommandResult:
+    accepted: Optional[bool] = field(default=None, metadata={"json": "Accepted"})
 
 
 @dataclass
@@ -318,7 +513,448 @@ class V1SessionList:
     page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
 
 
+@dataclass
+class V1FeishuChannelConfig:
+    app_id: Optional[str] = field(default=None, metadata={"json": "AppID"})
+    app_secret: Optional[str] = field(default=None, metadata={"json": "AppSecret"})
+    encrypt_key: Optional[str] = field(default=None, metadata={"json": "EncryptKey"})
+    verification_token: Optional[str] = field(
+        default=None, metadata={"json": "VerificationToken"}
+    )
+    domain: Optional[str] = field(default=None, metadata={"json": "Domain"})
+    connection_mode: Optional[str] = field(
+        default=None, metadata={"json": "ConnectionMode"}
+    )
+    webhook_path: Optional[str] = field(default=None, metadata={"json": "WebhookPath"})
+    require_mention: Optional[bool] = field(
+        default=None, metadata={"json": "RequireMention"}
+    )
+    render_mode: Optional[str] = field(default=None, metadata={"json": "RenderMode"})
+    streaming: Optional[bool] = field(default=None, metadata={"json": "Streaming"})
+    reaction_level: Optional[str] = field(
+        default=None, metadata={"json": "ReactionLevel"}
+    )
+    text_chunk_limit: Optional[int] = field(
+        default=None, metadata={"json": "TextChunkLimit"}
+    )
+    media_max_mb: Optional[int] = field(default=None, metadata={"json": "MediaMaxMB"})
+    block_reply: Optional[bool] = field(default=None, metadata={"json": "BlockReply"})
+
+
+@dataclass
+class V1WeComChannelConfig:
+    bot_id: Optional[str] = field(default=None, metadata={"json": "BotID"})
+    secret: Optional[str] = field(default=None, metadata={"json": "Secret"})
+
+
+@dataclass
+class V1Channel:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    agent_id: Optional[str] = field(default=None, metadata={"json": "AgentID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    channel_type: Optional[str] = field(default=None, metadata={"json": "ChannelType"})
+    config: Optional[Any] = field(default=None, metadata={"json": "Config"})
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+    assigned_gateway_id: Optional[str] = field(
+        default=None, metadata={"json": "AssignedGatewayID"}
+    )
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+    created_by: Optional[str] = field(default=None, metadata={"json": "CreatedBy"})
+    updated_by: Optional[str] = field(default=None, metadata={"json": "UpdatedBy"})
+    feishu_config: Optional[V1FeishuChannelConfig] = field(
+        default=None, metadata={"json": "FeishuConfig"}
+    )
+    wecom_config: Optional[V1WeComChannelConfig] = field(
+        default=None, metadata={"json": "WeComConfig"}
+    )
+
+
+@dataclass
+class V1RuntimeAPIKey:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    agent_id: Optional[str] = field(default=None, metadata={"json": "AgentID"})
+    key_mask: Optional[str] = field(default=None, metadata={"json": "KeyMask"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    expires_at: Optional[str] = field(default=None, metadata={"json": "ExpiresAt"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+
+
+@dataclass
+class V1RuntimeAPIKeyCreateResult:
+    item: Optional[V1RuntimeAPIKey] = field(default=None, metadata={"json": "Item"})
+    raw_key: Optional[str] = field(default=None, metadata={"json": "RawKey"})
+
+
+@dataclass
+class V1Run:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    tenant_id: Optional[str] = field(default=None, metadata={"json": "TenantID"})
+    agent_id: Optional[str] = field(default=None, metadata={"json": "AgentID"})
+    session_id: Optional[str] = field(default=None, metadata={"json": "SessionID"})
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+    source: Optional[str] = field(default=None, metadata={"json": "Source"})
+    input: Optional[str] = field(default=None, metadata={"json": "Input"})
+    output: Optional[str] = field(default=None, metadata={"json": "Output"})
+    iterations: Optional[int] = field(default=None, metadata={"json": "Iterations"})
+    tool_calls: Optional[int] = field(default=None, metadata={"json": "ToolCalls"})
+    tokens_input: Optional[int] = field(default=None, metadata={"json": "TokensInput"})
+    tokens_output: Optional[int] = field(
+        default=None, metadata={"json": "TokensOutput"}
+    )
+    metadata: Optional[Any] = field(default=None, metadata={"json": "Metadata"})
+    started_at: Optional[str] = field(default=None, metadata={"json": "StartedAt"})
+    completed_at: Optional[str] = field(default=None, metadata={"json": "CompletedAt"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+
+
+@dataclass
+class V1CronJob:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    workspace_id: Optional[str] = field(default=None, metadata={"json": "WorkspaceID"})
+    agent_id: Optional[str] = field(default=None, metadata={"json": "AgentID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    prompt: Optional[str] = field(default=None, metadata={"json": "Prompt"})
+    schedule_type: Optional[str] = field(
+        default=None, metadata={"json": "ScheduleType"}
+    )
+    schedule_value: Optional[str] = field(
+        default=None, metadata={"json": "ScheduleValue"}
+    )
+    schedule_timezone: Optional[str] = field(
+        default=None, metadata={"json": "ScheduleTimezone"}
+    )
+    delivery_channel: Optional[str] = field(
+        default=None, metadata={"json": "DeliveryChannel"}
+    )
+    delivery_to: Optional[str] = field(default=None, metadata={"json": "DeliveryTo"})
+    enabled: Optional[bool] = field(default=None, metadata={"json": "Enabled"})
+    source: Optional[str] = field(default=None, metadata={"json": "Source"})
+    next_run_at: Optional[str] = field(default=None, metadata={"json": "NextRunAt"})
+    last_status: Optional[str] = field(default=None, metadata={"json": "LastStatus"})
+    last_run_at: Optional[str] = field(default=None, metadata={"json": "LastRunAt"})
+    last_run_id: Optional[str] = field(default=None, metadata={"json": "LastRunID"})
+    config: Optional[Any] = field(default=None, metadata={"json": "Config"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+    created_by: Optional[str] = field(default=None, metadata={"json": "CreatedBy"})
+    updated_by: Optional[str] = field(default=None, metadata={"json": "UpdatedBy"})
+    created_via: Optional[str] = field(default=None, metadata={"json": "CreatedVia"})
+    created_session_id: Optional[str] = field(
+        default=None, metadata={"json": "CreatedSessionID"}
+    )
+
+
+@dataclass
+class V1CronJobList:
+    items: List[V1CronJob] = field(default_factory=list, metadata={"json": "Items"})
+    page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
+
+
+@dataclass
+class V1CronJobRun:
+    started_at: Optional[str] = field(default=None, metadata={"json": "StartedAt"})
+    finished_at: Optional[str] = field(default=None, metadata={"json": "FinishedAt"})
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+    trigger_type: Optional[str] = field(default=None, metadata={"json": "TriggerType"})
+    delivery_channel: Optional[str] = field(
+        default=None, metadata={"json": "DeliveryChannel"}
+    )
+    result: Optional[str] = field(default=None, metadata={"json": "Result"})
+
+
+@dataclass
+class V1CronJobRunSync:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    tenant_id: Optional[str] = field(default=None, metadata={"json": "TenantID"})
+    workspace_id: Optional[str] = field(default=None, metadata={"json": "WorkspaceID"})
+    agent_id: Optional[str] = field(default=None, metadata={"json": "AgentID"})
+    cron_job_id: Optional[str] = field(default=None, metadata={"json": "CronJobID"})
+    session_id: Optional[str] = field(default=None, metadata={"json": "SessionID"})
+    prompt: Optional[str] = field(default=None, metadata={"json": "Prompt"})
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+    scheduled_at: Optional[str] = field(default=None, metadata={"json": "ScheduledAt"})
+    trigger_type: Optional[str] = field(default=None, metadata={"json": "TriggerType"})
+    started_at: Optional[str] = field(default=None, metadata={"json": "StartedAt"})
+    finished_at: Optional[str] = field(default=None, metadata={"json": "FinishedAt"})
+    result: Optional[str] = field(default=None, metadata={"json": "Result"})
+
+
+@dataclass
+class V1CronJobRunList:
+    items: List[V1CronJobRun] = field(default_factory=list, metadata={"json": "Items"})
+    page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
+
+
+@dataclass
+class V1CronJobRunSyncList:
+    items: List[V1CronJobRunSync] = field(
+        default_factory=list, metadata={"json": "Items"}
+    )
+    next_cursor_updated_at: Optional[str] = field(
+        default=None, metadata={"json": "NextCursorUpdatedAt"}
+    )
+    next_cursor_id: Optional[str] = field(
+        default=None, metadata={"json": "NextCursorID"}
+    )
+
+
+@dataclass
+class V1CronJobCreateResult:
+    cron_job_id: Optional[str] = field(default=None, metadata={"json": "CronJobID"})
+    next_run_at: Optional[str] = field(default=None, metadata={"json": "NextRunAt"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+
+
+@dataclass
+class V1CronJobRunNowResult:
+    cron_job_id: Optional[str] = field(default=None, metadata={"json": "CronJobID"})
+    status: Optional[str] = field(default=None, metadata={"json": "Status"})
+    trigger_type: Optional[str] = field(default=None, metadata={"json": "TriggerType"})
+
+
+@dataclass
+class V1TraceSummary:
+    trace_id: Optional[str] = field(default=None, metadata={"json": "TraceID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    start_time: Optional[str] = field(default=None, metadata={"json": "StartTime"})
+    end_time: Optional[str] = field(default=None, metadata={"json": "EndTime"})
+    duration_ms: Optional[int] = field(default=None, metadata={"json": "DurationMs"})
+    agent_id: Optional[str] = field(default=None, metadata={"json": "AgentID"})
+    agent_name: Optional[str] = field(default=None, metadata={"json": "AgentName"})
+    status_code: Optional[str] = field(default=None, metadata={"json": "StatusCode"})
+    service_name: Optional[str] = field(default=None, metadata={"json": "ServiceName"})
+    attributes: Optional[Any] = field(default=None, metadata={"json": "Attributes"})
+
+
+@dataclass
+class V1SpanSummary:
+    trace_id: Optional[str] = field(default=None, metadata={"json": "TraceID"})
+    span_id: Optional[str] = field(default=None, metadata={"json": "SpanID"})
+    parent_span_id: Optional[str] = field(
+        default=None, metadata={"json": "ParentSpanID"}
+    )
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    kind: Optional[str] = field(default=None, metadata={"json": "Kind"})
+    start_time: Optional[str] = field(default=None, metadata={"json": "StartTime"})
+    end_time: Optional[str] = field(default=None, metadata={"json": "EndTime"})
+    duration_ms: Optional[int] = field(default=None, metadata={"json": "DurationMs"})
+    status_code: Optional[str] = field(default=None, metadata={"json": "StatusCode"})
+    status_message: Optional[str] = field(
+        default=None, metadata={"json": "StatusMessage"}
+    )
+    service_name: Optional[str] = field(default=None, metadata={"json": "ServiceName"})
+
+
+@dataclass
+class V1SpanDetail:
+    trace_id: Optional[str] = field(default=None, metadata={"json": "TraceID"})
+    span_id: Optional[str] = field(default=None, metadata={"json": "SpanID"})
+    parent_span_id: Optional[str] = field(
+        default=None, metadata={"json": "ParentSpanID"}
+    )
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    kind: Optional[str] = field(default=None, metadata={"json": "Kind"})
+    start_time: Optional[str] = field(default=None, metadata={"json": "StartTime"})
+    end_time: Optional[str] = field(default=None, metadata={"json": "EndTime"})
+    duration_ms: Optional[int] = field(default=None, metadata={"json": "DurationMs"})
+    status_code: Optional[str] = field(default=None, metadata={"json": "StatusCode"})
+    status_message: Optional[str] = field(
+        default=None, metadata={"json": "StatusMessage"}
+    )
+    resource: Optional[Any] = field(default=None, metadata={"json": "Resource"})
+    attributes: Optional[Any] = field(default=None, metadata={"json": "Attributes"})
+    events: Optional[List[Any]] = field(default=None, metadata={"json": "Events"})
+
+
+@dataclass
+class V1TraceList:
+    items: List[V1TraceSummary] = field(
+        default_factory=list, metadata={"json": "Items"}
+    )
+    next_scroll_id: Optional[str] = field(
+        default=None, metadata={"json": "NextScrollID"}
+    )
+    total: Optional[int] = field(default=None, metadata={"json": "Total"})
+
+
+@dataclass
+class V1SpanList:
+    items: List[V1SpanSummary] = field(default_factory=list, metadata={"json": "Items"})
+    next_scroll_id: Optional[str] = field(
+        default=None, metadata={"json": "NextScrollID"}
+    )
+    total: Optional[int] = field(default=None, metadata={"json": "Total"})
+
+
+@dataclass
+class V1Overview:
+    summary: Optional[Any] = field(default=None, metadata={"json": "Summary"})
+    run_health: Optional[Any] = field(default=None, metadata={"json": "RunHealth"})
+    usage: Optional[Any] = field(default=None, metadata={"json": "Usage"})
+    risk: Optional[Any] = field(default=None, metadata={"json": "Risk"})
+
+
+@dataclass
+class V1MetricDataPoint:
+    time: Optional[str] = field(default=None, metadata={"json": "Time"})
+    value: Optional[float] = field(default=None, metadata={"json": "Value"})
+    start_timestamp: Optional[int] = field(
+        default=None, metadata={"json": "StartTimestamp"}
+    )
+    end_timestamp: Optional[int] = field(
+        default=None, metadata={"json": "EndTimestamp"}
+    )
+
+
+@dataclass
+class V1MetricGroupedDataPoint:
+    group: Optional[str] = field(default=None, metadata={"json": "Group"})
+    points: List[V1MetricDataPoint] = field(
+        default_factory=list, metadata={"json": "Points"}
+    )
+
+
+@dataclass
+class V1MetricOverview:
+    request_count: Optional[int] = field(
+        default=None, metadata={"json": "RequestCount"}
+    )
+    success_rate: Optional[float] = field(
+        default=None, metadata={"json": "SuccessRate"}
+    )
+    avg_latency_ms: Optional[float] = field(
+        default=None, metadata={"json": "AvgLatencyMs"}
+    )
+    latency_p50_ms: Optional[float] = field(
+        default=None, metadata={"json": "LatencyP50Ms"}
+    )
+    latency_p95_ms: Optional[float] = field(
+        default=None, metadata={"json": "LatencyP95Ms"}
+    )
+    token_total: Optional[int] = field(default=None, metadata={"json": "TokenTotal"})
+    cost_total: Optional[float] = field(default=None, metadata={"json": "CostTotal"})
+
+
+@dataclass
+class V1MetricOverviewResult:
+    data: Optional[V1MetricOverview] = field(default=None, metadata={"json": "Data"})
+    effective_step_seconds: Optional[int] = field(
+        default=None, metadata={"json": "EffectiveStepSeconds"}
+    )
+
+
+@dataclass
+class V1MetricTrendResult:
+    series: Optional[List[V1MetricDataPoint]] = field(
+        default=None, metadata={"json": "Series"}
+    )
+    grouped: Optional[List[V1MetricGroupedDataPoint]] = field(
+        default=None, metadata={"json": "Grouped"}
+    )
+    effective_step_seconds: Optional[int] = field(
+        default=None, metadata={"json": "EffectiveStepSeconds"}
+    )
+
+
+@dataclass
+class V1MetricTopKItem:
+    group: Optional[str] = field(default=None, metadata={"json": "Group"})
+    value: Optional[float] = field(default=None, metadata={"json": "Value"})
+
+
+@dataclass
+class V1MetricTopKResult:
+    items: List[V1MetricTopKItem] = field(
+        default_factory=list, metadata={"json": "Items"}
+    )
+    effective_limit: Optional[int] = field(
+        default=None, metadata={"json": "EffectiveLimit"}
+    )
+
+
+@dataclass
+class V1MetricBreakdownResult:
+    groups: List[V1MetricGroupedDataPoint] = field(
+        default_factory=list, metadata={"json": "Groups"}
+    )
+    effective_step_seconds: Optional[int] = field(
+        default=None, metadata={"json": "EffectiveStepSeconds"}
+    )
+
+
+@dataclass
+class V1MemoryStore:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    workspace_id: Optional[str] = field(default=None, metadata={"json": "WorkspaceID"})
+    name: Optional[str] = field(default=None, metadata={"json": "Name"})
+    alias: Optional[str] = field(default=None, metadata={"json": "Alias"})
+    description: Optional[str] = field(default=None, metadata={"json": "Description"})
+    owner_type: Optional[str] = field(default=None, metadata={"json": "OwnerType"})
+    owner_id: Optional[str] = field(default=None, metadata={"json": "OwnerID"})
+    visibility: Optional[str] = field(default=None, metadata={"json": "Visibility"})
+    access: Optional[str] = field(default=None, metadata={"json": "Access"})
+    retrieval_mode: Optional[str] = field(
+        default=None, metadata={"json": "RetrievalMode"}
+    )
+    extraction_policy: Optional[Any] = field(
+        default=None, metadata={"json": "ExtractionPolicy"}
+    )
+    quota_policy: Optional[Any] = field(default=None, metadata={"json": "QuotaPolicy"})
+    file_count: Optional[int] = field(default=None, metadata={"json": "FileCount"})
+    bytes_used: Optional[int] = field(default=None, metadata={"json": "BytesUsed"})
+    created_by: Optional[str] = field(default=None, metadata={"json": "CreatedBy"})
+    updated_by: Optional[str] = field(default=None, metadata={"json": "UpdatedBy"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+
+
+@dataclass
+class V1MemoryStoreList:
+    items: List[V1MemoryStore] = field(default_factory=list, metadata={"json": "Items"})
+    page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
+
+
+@dataclass
+class V1MemoryFile:
+    id: Optional[str] = field(default=None, metadata={"json": "ID"})
+    store_id: Optional[str] = field(default=None, metadata={"json": "StoreID"})
+    path: Optional[str] = field(default=None, metadata={"json": "Path"})
+    artifact_id: Optional[str] = field(default=None, metadata={"json": "ArtifactID"})
+    content_sha256: Optional[str] = field(
+        default=None, metadata={"json": "ContentSha256"}
+    )
+    size_bytes: Optional[int] = field(default=None, metadata={"json": "SizeBytes"})
+    mime_type: Optional[str] = field(default=None, metadata={"json": "MimeType"})
+    revision: Optional[int] = field(default=None, metadata={"json": "Revision"})
+    content: Optional[str] = field(default=None, metadata={"json": "Content"})
+    created_by: Optional[str] = field(default=None, metadata={"json": "CreatedBy"})
+    updated_by: Optional[str] = field(default=None, metadata={"json": "UpdatedBy"})
+    created_at: Optional[str] = field(default=None, metadata={"json": "CreatedAt"})
+    updated_at: Optional[str] = field(default=None, metadata={"json": "UpdatedAt"})
+
+
+@dataclass
+class V1MemoryFileList:
+    items: List[V1MemoryFile] = field(default_factory=list, metadata={"json": "Items"})
+    page: Optional[V1Page] = field(default=None, metadata={"json": "Page"})
+
+
+@dataclass
+class V1MemoryFileUpsertResult:
+    file_id: Optional[str] = field(default=None, metadata={"json": "FileID"})
+    path: Optional[str] = field(default=None, metadata={"json": "Path"})
+    content_sha256: Optional[str] = field(
+        default=None, metadata={"json": "ContentSha256"}
+    )
+    revision: Optional[int] = field(default=None, metadata={"json": "Revision"})
+    size_bytes: Optional[int] = field(default=None, metadata={"json": "SizeBytes"})
+
+
 # ---------------- Param types (snake_case input) ----------------
+
 
 @dataclass
 class V1UploadBlobParams:
@@ -336,6 +972,7 @@ class V1EnvironmentNewParams:
     memory_limit: str = ""
     pvc_size: str = ""
     data_path: str = ""
+    spec_code: str = ""
     workspace_id: str = ""
 
 
@@ -351,6 +988,7 @@ class V1EnvironmentUpdateParams:
     memory_limit: Optional[str] = None
     pvc_size: Optional[str] = None
     data_path: Optional[str] = None
+    spec_code: Optional[str] = None
 
 
 @dataclass
@@ -515,6 +1153,27 @@ class V1ResourceBatchGetParams:
 
 
 @dataclass
+class V1ResourceBatchCreateItemParams:
+    name: str
+    blob_id: str
+    directory_id: str = ""
+
+
+@dataclass
+class V1ResourceBatchCreateParams:
+    items: List[V1ResourceBatchCreateItemParams]
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ResourceMoveParams:
+    resource_id: str
+    old_directory_id: str = ""
+    new_directory_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
 class V1DirectoryNewParams:
     name: str
     workspace_id: str = ""
@@ -611,6 +1270,12 @@ class V1MCPGetParams:
 
 
 @dataclass
+class V1MCPBatchGetParams:
+    ids: List[str]
+    workspace_id: str = ""
+
+
+@dataclass
 class V1MCPUpdateParams:
     id: str
     name: Optional[str] = None
@@ -674,6 +1339,31 @@ class V1SkillNewParams:
 
 
 @dataclass
+class V1SkillParseParams:
+    blob_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ArkSkillHubListParams:
+    keyword: str = ""
+    workspace_id: str = ""
+    page: Optional[V1PageInput] = None
+
+
+@dataclass
+class V1ArkSkillHubGetParams:
+    slug: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ArkSkillHubImportParams:
+    slug: str
+    workspace_id: str = ""
+
+
+@dataclass
 class V1SkillListParams:
     keyword: str = ""
     source: str = ""
@@ -692,6 +1382,12 @@ class V1SkillGetParams:
 
 
 @dataclass
+class V1SkillBatchGetParams:
+    ids: List[str]
+    workspace_id: str = ""
+
+
+@dataclass
 class V1SkillUpdateParams:
     id: str = ""
     skill_id: str = ""
@@ -699,6 +1395,7 @@ class V1SkillUpdateParams:
     description: Optional[str] = None
     source: Optional[str] = None
     artifact_id: Optional[str] = None
+    blob_id: Optional[str] = None
     enabled: Optional[bool] = None
     new_version: Optional[str] = None
     slug_id: Optional[str] = None
@@ -740,12 +1437,16 @@ class V1ManagedAgentModelConfigParams:
 class V1ManagedAgentSkillToolParams:
     skill_version_id: str
     type: str = V1_MANAGED_AGENT_SKILL_TOOL_PARAMS_TYPE_SKILL
+    enabled: Optional[bool] = None
 
 
 @dataclass
 class V1ManagedAgentMCPToolParams:
     id: str
     type: str = V1_MANAGED_AGENT_MCP_TOOL_PARAMS_TYPE_MCP
+    enabled: Optional[bool] = None
+    tool_allowlist: Optional[List[str]] = None
+    tool_denylist: Optional[List[str]] = None
 
 
 @dataclass
@@ -769,6 +1470,14 @@ class V1AgentNewParams:
     tools: Optional[List[V1AgentNewParamsToolUnion]] = None
     resources: Optional[List[V1ManagedAgentResourceRefParams]] = None
     workspace_id: str = ""
+    description: Optional[str] = None
+    channels: Optional[List[Any]] = None
+    config: Optional[Any] = None
+    metadata: Optional[Dict[str, str]] = None
+    icon: Optional[str] = None
+    api_protocol_type: Optional[str] = None
+    model_interactive_mode: Optional[str] = None
+    egress_credentials: Optional[List[Any]] = None
 
 
 @dataclass
@@ -801,10 +1510,35 @@ class V1AgentUpdateParams:
     resources: Optional[List[V1ManagedAgentResourceRefParams]] = None
     reset_resources: bool = False
     workspace_id: str = ""
+    config: Optional[Any] = None
+    metadata: Optional[Dict[str, str]] = None
+    memory_stores: Optional[List[Any]] = None
+    icon: Optional[str] = None
+    api_protocol_type: Optional[str] = None
+    model_interactive_mode: Optional[str] = None
+    egress_credentials: Optional[List[Any]] = None
 
 
 @dataclass
 class V1AgentDeleteParams:
+    agent_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1AgentRetryCreateParams:
+    agent_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1AgentStopParams:
+    agent_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1AgentResumeParams:
     agent_id: str
     workspace_id: str = ""
 
@@ -823,6 +1557,12 @@ class V1SessionNewParams:
     # peer 仅在显式指定 IM 渠道或按 user 隔离会话时填写；webchat 主流程留空即可。
     peer: Optional[V1SessionPeerParams] = None
     workspace_id: str = ""
+    session_key: str = ""
+    risk_level: str = ""
+    config: Optional[Any] = None
+    auth_context: Optional[Any] = None
+    metadata: Optional[Any] = None
+    conversation_id: str = ""
 
 
 @dataclass
@@ -832,6 +1572,7 @@ class V1SessionChatParams:
     client_message_id: str = ""
     files: Optional[List[V1MessageFile]] = None
     workspace_id: str = ""
+    conversation_id: str = ""
 
 
 @dataclass
@@ -841,6 +1582,14 @@ class V1SessionListParams:
     channel: str = ""
     workspace_id: str = ""
     page: Optional[V1PageInput] = None
+    session_keys: Optional[List[str]] = None
+    user_id: str = ""
+
+
+@dataclass
+class V1SessionBatchGetParams:
+    session_ids: List[str]
+    workspace_id: str = ""
 
 
 @dataclass
@@ -876,6 +1625,8 @@ class V1MessageListParams:
     visibility: str = ""
     workspace_id: str = ""
     page: Optional[V1PageInput] = None
+    display_mode: str = ""
+    base_message_id: str = ""
 
 
 @dataclass
@@ -890,10 +1641,416 @@ class V1MessageInjectParams:
     session_id: str
     role: str = ""
     content: str = ""
+    tool_calls: Optional[Any] = None
+    tool_result: Optional[Any] = None
+    metadata: Optional[Any] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ChatResumeParams:
+    session_id: str
+    agent_id: str = ""
+    run_id: str = ""
+    request_id: str = ""
+    last_event_id: str = ""
+    approve: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ChatApproveParams:
+    session_id: str
+    run_id: str
+    approval_request_id: str
+    choice_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ChatCancelRunParams:
+    session_id: str
+    run_id: str
+    reason: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1FeishuChannelConfigParams:
+    app_id: str = ""
+    app_secret: str = ""
+    encrypt_key: Optional[str] = None
+    verification_token: Optional[str] = None
+    domain: Optional[str] = None
+    connection_mode: Optional[str] = None
+    webhook_path: Optional[str] = None
+    require_mention: Optional[bool] = None
+    render_mode: Optional[str] = None
+    streaming: Optional[bool] = None
+    reaction_level: Optional[str] = None
+    text_chunk_limit: Optional[int] = None
+    media_max_mb: Optional[int] = None
+    block_reply: Optional[bool] = None
+
+
+@dataclass
+class V1WeComChannelConfigParams:
+    bot_id: str = ""
+    secret: str = ""
+
+
+@dataclass
+class V1ChannelNewParams:
+    agent_id: str
+    name: str
+    channel_type: str = ""
+    dm_policy: str = ""
+    group_policy: str = ""
+    allowlist: Optional[List[str]] = None
+    feishu_config: Optional[V1FeishuChannelConfigParams] = None
+    wecom_config: Optional[V1WeComChannelConfigParams] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ChannelListParams:
+    agent_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ChannelGetParams:
+    channel_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ChannelUpdateParams:
+    channel_id: str
+    name: Optional[str] = None
+    channel_type: Optional[str] = None
+    target_agent_id: Optional[str] = None
+    dm_policy: Optional[str] = None
+    group_policy: Optional[str] = None
+    allowlist: Optional[List[str]] = None
+    feishu_config: Optional[V1FeishuChannelConfigParams] = None
+    wecom_config: Optional[V1WeComChannelConfigParams] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1ChannelDeleteParams:
+    channel_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1RuntimeAPIKeyNewParams:
+    agent_id: str
+    expired: str
+    description: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1RuntimeAPIKeyListParams:
+    agent_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1RuntimeAPIKeyUserInfoParams:
+    user_name: str
+    password: str
+
+
+@dataclass
+class V1RuntimeAPIKeyGetParams:
+    agent_id: str
+    id: str
+    user_info: V1RuntimeAPIKeyUserInfoParams
+    workspace_id: str = ""
+
+
+@dataclass
+class V1RuntimeAPIKeyUpdateParams:
+    agent_id: str
+    id: str
+    description: Optional[str] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1RuntimeAPIKeyDeleteParams:
+    agent_id: str
+    id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1RunListParams:
+    agent_id: str = ""
+    session_id: str = ""
+    status: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1RunGetParams:
+    run_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1CronJobListParams:
+    agent_id: str = ""
+    source: str = ""
+    enabled: Optional[bool] = None
+    page: Optional[V1PageInput] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1CronJobRunListParams:
+    cron_job_id: str
+    page: Optional[V1PageInput] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1CronJobRunSyncListParams:
+    cursor_updated_at: str = ""
+    cursor_id: str = ""
+    page_size: Optional[int] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1CronJobGetParams:
+    cron_job_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1CronJobNewParams:
+    agent_id: str
+    name: str
+    prompt: str
+    schedule_type: str
+    schedule_value: str
+    delivery_channel: str
+    delivery_to: str
+    description: str = ""
+    schedule_timezone: str = ""
+    enabled: Optional[bool] = None
+    config: Optional[Any] = None
+    correlation_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1CronJobUpdateParams:
+    cron_job_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    prompt: Optional[str] = None
+    schedule_type: Optional[str] = None
+    schedule_value: Optional[str] = None
+    schedule_timezone: Optional[str] = None
+    delivery_channel: Optional[str] = None
+    delivery_to: Optional[str] = None
+    enabled: Optional[bool] = None
+    config: Optional[Any] = None
+    update_fields: Optional[List[str]] = None
+    correlation_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1CronJobDeleteParams:
+    cron_job_id: str
+    cancel_running: Optional[bool] = None
+    correlation_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1CronJobToggleParams:
+    cron_job_id: str
+    enabled: bool
+    correlation_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1CronJobRunNowParams:
+    cron_job_id: str
+    correlation_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1TraceListParams:
+    scroll_id: str = ""
+    page_size: Optional[int] = None
+    session_id: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SpanListParams:
+    trace_id: str
+    scroll_id: str = ""
+    page_size: Optional[int] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1SpanGetParams:
+    trace_id: str
+    span_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MetricAggregatorParams:
+    start_time: str
+    end_time: str
+    step_seconds: Optional[int] = None
+
+
+@dataclass
+class V1MetricFilterParams:
+    workspace_id: str = ""
+    agent_ids: Optional[List[str]] = None
+    channels: Optional[List[str]] = None
+    models: Optional[List[str]] = None
+    statuses: Optional[List[str]] = None
+    response_modes: Optional[List[str]] = None
+
+
+@dataclass
+class V1MetricOverviewParams:
+    aggregator: V1MetricAggregatorParams
+    filter: V1MetricFilterParams = field(default_factory=V1MetricFilterParams)
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MetricTrendParams:
+    metric: str
+    aggregator: V1MetricAggregatorParams
+    filter: V1MetricFilterParams = field(default_factory=V1MetricFilterParams)
+    group_by: str = ""
+    statistic: str = ""
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MetricTopKParams:
+    metric: str
+    group_by: str
+    aggregator: V1MetricAggregatorParams
+    limit: int
+    filter: V1MetricFilterParams = field(default_factory=V1MetricFilterParams)
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MetricBreakdownParams:
+    metric: str
+    group_by: str
+    aggregator: V1MetricAggregatorParams
+    filter: V1MetricFilterParams = field(default_factory=V1MetricFilterParams)
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MemoryStoreNewParams:
+    name: str
+    alias: str
+    description: str
+    access: str = ""
+    extraction_policy: Optional[Any] = None
+    quota_policy: Optional[Any] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MemoryStoreListParams:
+    keyword: str = ""
+    page: Optional[V1PageInput] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MemoryStoreGetParams:
+    store_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MemoryStoreUpdateParams:
+    store_id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    access: Optional[str] = None
+    extraction_policy: Optional[Any] = None
+    quota_policy: Optional[Any] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MemoryStoreDeleteParams:
+    store_id: str
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MemoryFileListParams:
+    store_id: str
+    prefix: str = ""
+    page: Optional[V1PageInput] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MemoryFileSearchParams:
+    store_id: str
+    keyword: str
+    page: Optional[V1PageInput] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MemoryFileGetParams:
+    store_id: str
+    path: str
+    include_content: Optional[bool] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MemoryFileUpsertParams:
+    store_id: str
+    path: str
+    content: str
+    base_sha256: str = ""
+    base_revision: Optional[int] = None
+    workspace_id: str = ""
+
+
+@dataclass
+class V1MemoryFileDeleteParams:
+    store_id: str
+    path: str
+    base_sha256: str = ""
+    base_revision: Optional[int] = None
     workspace_id: str = ""
 
 
 # Stream event types
+
 
 @dataclass
 class V1SessionTextDelta:
@@ -916,4 +2073,6 @@ class V1SessionChatEvent:
     raw_data: str = ""
 
 
-__all__ = [name for name in globals() if name.startswith("V1") or name.startswith("_from_dict")]
+__all__ = [
+    name for name in globals() if name.startswith("V1") or name.startswith("_from_dict")
+]

--- a/libs/hibot/tests/test_agents.py
+++ b/libs/hibot/tests/test_agents.py
@@ -12,6 +12,9 @@ from hibot import (
     V1AgentGetParams,
     V1AgentNewParams,
     V1AgentNewParamsToolUnion,
+    V1AgentResumeParams,
+    V1AgentRetryCreateParams,
+    V1AgentStopParams,
     V1ManagedAgentMCPToolParams,
     V1ManagedAgentModelConfigParams,
     V1ManagedAgentResourceRefParams,
@@ -24,7 +27,9 @@ def _query_action(req: httpx.Request) -> str:
     return q.get("Action", [""])[0]
 
 
-def test_create_agent_auto_resolves_default_environment(client_factory, make_handler, ok_envelope):
+def test_create_agent_auto_resolves_default_environment(
+    client_factory, make_handler, ok_envelope
+):
     # Sequence: ListEnv -> [{ID:e1,...}, {ID:e2,...}], then CreateAgent.
     list_envs_reply = ok_envelope(
         {
@@ -47,11 +52,13 @@ def test_create_agent_auto_resolves_default_environment(client_factory, make_han
             V1AgentNewParamsToolUnion(
                 of_skill=V1ManagedAgentSkillToolParams(skill_version_id="sv-1")
             ),
-            V1AgentNewParamsToolUnion(
-                of_mcp=V1ManagedAgentMCPToolParams(id="mcp-1")
-            ),
+            V1AgentNewParamsToolUnion(of_mcp=V1ManagedAgentMCPToolParams(id="mcp-1")),
         ],
         resources=[V1ManagedAgentResourceRefParams(id="res-1")],
+        description="demo",
+        metadata={"team": "sdk"},
+        api_protocol_type="responses",
+        model_interactive_mode="direct",
     )
     agent = client.v1.agents.create(params)
     assert agent.id == "agent-1"
@@ -73,6 +80,10 @@ def test_create_agent_auto_resolves_default_environment(client_factory, make_han
     assert body["Skills"] == [{"ID": "sv-1"}]
     assert body["MCPs"] == [{"ID": "mcp-1", "Enabled": True}]
     assert body["Resources"] == {"ResourceIDs": ["res-1"]}
+    assert body["Description"] == "demo"
+    assert body["Metadata"] == {"team": "sdk"}
+    assert body["ApiProtocolType"] == "responses"
+    assert body["ModelInteractiveMode"] == "direct"
 
 
 def test_get_agent_requires_agent_id(client_factory, make_handler):
@@ -93,3 +104,24 @@ def test_delete_agent_uses_server_service(client_factory, make_handler, ok_envel
     # Service routed to server
     q = parse_qs(urlsplit(str(req.url)).query)
     assert q["Version"][0] == "2026-04-23"
+
+
+def test_agent_lifecycle_actions_use_server(client_factory, make_handler, ok_envelope):
+    handler = make_handler([ok_envelope({}), ok_envelope({}), ok_envelope({})])
+    client = client_factory(handler)
+
+    client.v1.agents.retry_create(V1AgentRetryCreateParams(agent_id="a-1"))
+    client.v1.agents.stop(V1AgentStopParams(agent_id="a-1"))
+    client.v1.agents.resume(V1AgentResumeParams(agent_id="a-1"))
+
+    assert [_query_action(request) for request in handler.calls] == [
+        "RetryCreateAgent",
+        "StopAgent",
+        "ResumeAgent",
+    ]
+    for request in handler.calls:
+        assert request.headers["x-top-service"] == "hibot-server"
+        assert json.loads(request.content) == {
+            "AgentID": "a-1",
+            "WorkspaceID": "ws-1",
+        }

--- a/libs/hibot/tests/test_basic_e2e_offline.py
+++ b/libs/hibot/tests/test_basic_e2e_offline.py
@@ -23,13 +23,6 @@ def _action(req: httpx.Request) -> str:
 
 
 def test_basic_e2e_offline(client_factory, make_handler, ok_envelope, sse):
-    sse_body = (
-        b'event: message_delta\n'
-        b'data: {"text":"Hi"}\n\n'
-        b'event: run_completed\n'
-        b'data: {"message":{"ID":"msg-1","Role":"assistant","Content":"Hi"}}\n\n'
-    )
-
     replies = [
         # uploads.upload_blob -> /up subpath
         ok_envelope({"BlobID": "blob-1"}),
@@ -41,8 +34,8 @@ def test_basic_e2e_offline(client_factory, make_handler, ok_envelope, sse):
         ok_envelope({"ID": "agent-1"}),
         # sessions.create
         ok_envelope({"ID": "sess-1"}),
-        # sessions.chat (gateway, SSE)
-        sse(sse_body),
+        # sessions.chat (server, synchronous JSON)
+        ok_envelope({"Message": "Hi"}),
     ]
     handler = make_handler(replies)
     client = client_factory(handler)
@@ -69,7 +62,7 @@ def test_basic_e2e_offline(client_factory, make_handler, ok_envelope, sse):
     assert session.id == "sess-1"
 
     msg = client.v1.sessions.chat(session.id, V1SessionChatParams(input="hi"))
-    assert msg.id == "msg-1"
+    assert msg.id is None
     assert msg.content == "Hi"
 
     # Verify routing & envelope expectations

--- a/libs/hibot/tests/test_chat_files_approve.py
+++ b/libs/hibot/tests/test_chat_files_approve.py
@@ -17,30 +17,24 @@ from hibot import (
 def test_chat_non_streaming_injects_approve_all(
     client_factory, make_handler, ok_envelope, sse
 ):
-    sse_body = (
-        b'event: run_completed\n'
-        b'data: {"message":{"ID":"m-1","Role":"assistant","Content":"ok"}}\n\n'
-    )
-    handler = make_handler([sse(sse_body)])
+    handler = make_handler([ok_envelope({"Message": "ok"})])
     client = client_factory(handler)
 
     msg = client.v1.sessions.chat(
         "s-1",
         V1SessionChatParams(input="hello", agent_id="agent-1"),
     )
-    assert msg.id == "m-1"
+    assert msg.content == "ok"
 
     body = json.loads(handler.calls[0].content)
     assert body["Approve"] == "all"
+    assert body["Stream"] is False
 
 
 def test_chat_streaming_does_not_inject_approve(
     client_factory, make_handler, ok_envelope, sse
 ):
-    sse_body = (
-        b'event: run_completed\n'
-        b'data: {"message":{"ID":"m-1"}}\n\n'
-    )
+    sse_body = b'event: run_completed\ndata: {"message":{"ID":"m-1"}}\n\n'
     handler = make_handler([sse(sse_body)])
     client = client_factory(handler)
 
@@ -52,19 +46,25 @@ def test_chat_streaming_does_not_inject_approve(
 
     body = json.loads(handler.calls[0].content)
     assert "Approve" not in body
+    assert body["Stream"] is True
 
 
 def test_chat_supports_files_and_empty_content(
     client_factory, make_handler, ok_envelope, sse
 ):
-    sse_body = (
-        b'event: run_completed\n'
-        b'data: {"message":{"ID":"m-1"}}\n\n'
+    handler = make_handler(
+        [
+            ok_envelope(
+                {
+                    "Message": "ok",
+                    "Files": [{"Name": "out.txt", "ContentType": "text/plain"}],
+                }
+            )
+        ]
     )
-    handler = make_handler([sse(sse_body)])
     client = client_factory(handler)
 
-    client.v1.sessions.chat(
+    msg = client.v1.sessions.chat(
         "s-1",
         V1SessionChatParams(
             agent_id="agent-1",
@@ -86,6 +86,8 @@ def test_chat_supports_files_and_empty_content(
     assert files[0]["Name"] == "report.pdf"
     assert files[0]["ContentType"] == "application/pdf"
     assert files[0]["BlobID"] == "blob-123"
+    assert msg.content == "ok"
+    assert msg.files and msg.files[0].name == "out.txt"
 
 
 def test_create_mcp_serializes_credential_config_secret_value(
@@ -126,9 +128,7 @@ def test_create_mcp_serializes_credential_config_secret_value(
     assert "Credential" not in body
 
 
-def test_update_mcp_passes_credential_config(
-    client_factory, make_handler, ok_envelope
-):
+def test_update_mcp_passes_credential_config(client_factory, make_handler, ok_envelope):
     handler = make_handler([ok_envelope({})])
     client = client_factory(handler)
 

--- a/libs/hibot/tests/test_environments.py
+++ b/libs/hibot/tests/test_environments.py
@@ -1,0 +1,59 @@
+"""Environment API contract tests."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+from hibot import V1EnvironmentNewParams
+
+
+def _action(req: httpx.Request) -> str:
+    return parse_qs(urlsplit(str(req.url)).query).get("Action", [""])[0]
+
+
+def test_environment_spec_code_and_workspace_catalog(
+    client_factory, make_handler, ok_envelope
+):
+    handler = make_handler(
+        [
+            ok_envelope({"ID": "env-1"}),
+            ok_envelope(
+                {
+                    "Specs": [
+                        {
+                            "SpecCode": "vci.u1.2c-4gi",
+                            "DisplayName": "Standard",
+                            "Cpu": "2",
+                            "Memory": "4Gi",
+                            "Storage": "20Gi",
+                            "IsDefault": True,
+                        }
+                    ]
+                }
+            ),
+        ]
+    )
+    client = client_factory(handler)
+
+    env = client.v1.environments.create(
+        params=V1EnvironmentNewParams(
+            name="runtime",
+            image_type="hermes",
+            spec_code="vci.u1.2c-4gi",
+        )
+    )
+    specs = client.v1.environments.list_workspace_specs()
+
+    assert env.id == "env-1"
+    assert len(specs) == 1
+    assert specs[0].spec_code == "vci.u1.2c-4gi"
+    assert specs[0].is_default is True
+    assert [_action(req) for req in handler.calls] == [
+        "CreateEnv",
+        "ListWorkspaceSpecs",
+    ]
+    create_body = json.loads(handler.calls[0].content)
+    assert create_body["Payload"]["SpecCode"] == "vci.u1.2c-4gi"
+    assert handler.calls[1].headers["x-top-service"] == "hibot-server"

--- a/libs/hibot/tests/test_full_journey_offline.py
+++ b/libs/hibot/tests/test_full_journey_offline.py
@@ -30,7 +30,7 @@ from hibot import (
     V1UploadBlobParams,
 )
 
-_V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO = "doubao-seed-2.0-pro-260215"
+_V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO = "doubao-seed-2-0-pro-260215"
 
 
 def _query(req: httpx.Request) -> dict:
@@ -48,9 +48,9 @@ def _path(req: httpx.Request) -> str:
 def _sse_chat_body() -> bytes:
     """Mirror mocktop's Chat handler: one delta + one completed event."""
     return (
-        b'event: delta\n'
+        b"event: delta\n"
         b'data: {"request_id":"req-test","delta":{"text":"ok"}}\n\n'
-        b'event: completed\n'
+        b"event: completed\n"
         b'data: {"request_id":"req-test","message":{"ID":"message-1","Content":"ok"}}\n\n'
     )
 
@@ -103,8 +103,8 @@ def test_full_journey_streaming_and_batch(
         ok_envelope({"ID": "session-1"}),
         # sessions.chat_streaming -> Chat (SSE)
         sse(sse_body),
-        # sessions.chat -> Chat (SSE)
-        sse(sse_body),
+        # sessions.chat -> Chat (synchronous JSON)
+        ok_envelope({"Message": "ok"}),
     ]
     handler = make_handler(replies)
     client = client_factory(handler, workspace_id="workspace-e2e")
@@ -245,19 +245,17 @@ def test_full_journey_streaming_and_batch(
             elif event.type == "completed":
                 saw_completed = True
             elif event.type == "failed":
-                raise AssertionError(
-                    f"streaming chat failed: {event.error.message}"
-                )
-        assert (
-            saw_completed
-        ), f"streaming chat: no completed event observed (events={streaming_event_names})"
-        assert (
-            saw_delta
-        ), f"streaming chat: no delta event observed (events={streaming_event_names})"
+                raise AssertionError(f"streaming chat failed: {event.error.message}")
+        assert saw_completed, (
+            f"streaming chat: no completed event observed (events={streaming_event_names})"
+        )
+        assert saw_delta, (
+            f"streaming chat: no delta event observed (events={streaming_event_names})"
+        )
         streaming_final = stream.final_message()
-    assert (
-        streaming_final.id and streaming_final.content
-    ), f"streaming final message incomplete: {streaming_final!r}"
+    assert streaming_final.id and streaming_final.content, (
+        f"streaming final message incomplete: {streaming_final!r}"
+    )
 
     # ---------------------------------------------------------------
     # Step 10 (batch): sessions.chat returns the final V1Message.
@@ -265,9 +263,7 @@ def test_full_journey_streaming_and_batch(
     batch_final = client.v1.sessions.chat(
         session.id, V1SessionChatParams(input="批量：再回答一次同样的问题。")
     )
-    assert (
-        batch_final.id and batch_final.content
-    ), f"batch final message incomplete: {batch_final!r}"
+    assert batch_final.content, f"batch final message content empty: {batch_final!r}"
 
     # ---------------------------------------------------------------
     # Step 11: action / routing / body / signing / SSE assertions.
@@ -309,9 +305,9 @@ def test_full_journey_streaming_and_batch(
     # /up subpath only for UploadBlob requests; everything else stays at root.
     for req in handler.calls:
         if _action(req) == "UploadBlob":
-            assert _path(req).endswith(
-                "/up"
-            ), f"UploadBlob path = {_path(req)}, want suffix /up"
+            assert _path(req).endswith("/up"), (
+                f"UploadBlob path = {_path(req)}, want suffix /up"
+            )
         else:
             assert _path(req) in (
                 "",
@@ -321,64 +317,64 @@ def test_full_journey_streaming_and_batch(
     # Every request carries a VOLC v4 Authorization header.
     for req in handler.calls:
         auth = req.headers.get("authorization", "")
-        assert auth.startswith(
-            "HMAC-SHA256 "
-        ), f"missing/invalid Authorization header for action={_action(req)}: {auth!r}"
+        assert auth.startswith("HMAC-SHA256 "), (
+            f"missing/invalid Authorization header for action={_action(req)}: {auth!r}"
+        )
 
     # CreateAgent body verification.
     create_agent_idx = actions.index("CreateAgent")
     create_agent_body = json.loads(handler.calls[create_agent_idx].content)
-    assert (
-        create_agent_body.get("WorkspaceID") == "workspace-e2e"
-    ), f"CreateAgent WorkspaceID = {create_agent_body.get('WorkspaceID')!r}, want workspace-e2e"
-    assert (
-        create_agent_body.get("ModelID") == model.id
-    ), f"CreateAgent ModelID = {create_agent_body.get('ModelID')!r}, want {model.id!r}"
-    assert (
-        create_agent_body.get("EnvID") == "env-1"
-    ), f"CreateAgent EnvID = {create_agent_body.get('EnvID')!r}, want env-1 (from ListEnv default)"
-    assert isinstance(
-        create_agent_body.get("Skills"), list
-    ), f"CreateAgent Skills missing or wrong type: {create_agent_body.get('Skills')!r}"
-    assert isinstance(
-        create_agent_body.get("MCPs"), list
-    ), f"CreateAgent MCPs missing or wrong type: {create_agent_body.get('MCPs')!r}"
-    assert isinstance(
-        create_agent_body.get("Resources"), dict
-    ), f"CreateAgent Resources missing or wrong shape: {create_agent_body.get('Resources')!r}"
+    assert create_agent_body.get("WorkspaceID") == "workspace-e2e", (
+        f"CreateAgent WorkspaceID = {create_agent_body.get('WorkspaceID')!r}, want workspace-e2e"
+    )
+    assert create_agent_body.get("ModelID") == model.id, (
+        f"CreateAgent ModelID = {create_agent_body.get('ModelID')!r}, want {model.id!r}"
+    )
+    assert create_agent_body.get("EnvID") == "env-1", (
+        f"CreateAgent EnvID = {create_agent_body.get('EnvID')!r}, want env-1 (from ListEnv default)"
+    )
+    assert isinstance(create_agent_body.get("Skills"), list), (
+        f"CreateAgent Skills missing or wrong type: {create_agent_body.get('Skills')!r}"
+    )
+    assert isinstance(create_agent_body.get("MCPs"), list), (
+        f"CreateAgent MCPs missing or wrong type: {create_agent_body.get('MCPs')!r}"
+    )
+    assert isinstance(create_agent_body.get("Resources"), dict), (
+        f"CreateAgent Resources missing or wrong shape: {create_agent_body.get('Resources')!r}"
+    )
 
     # CreateSession body verification.
     create_session_idx = actions.index("CreateSession")
     create_session_body = json.loads(handler.calls[create_session_idx].content)
-    assert (
-        create_session_body.get("AgentID") == agent.id
-    ), f"CreateSession AgentID = {create_session_body.get('AgentID')!r}, want {agent.id!r}"
+    assert create_session_body.get("AgentID") == agent.id, (
+        f"CreateSession AgentID = {create_session_body.get('AgentID')!r}, want {agent.id!r}"
+    )
     payload = create_session_body.get("Payload")
-    assert isinstance(
-        payload, dict
-    ), f"CreateSession Payload missing: {create_session_body!r}"
-    assert (
-        payload.get("Channel") == "webchat"
-    ), f"CreateSession Channel = {payload.get('Channel')!r}, want webchat"
-    assert (
-        payload.get("PeerKind") == "system"
-    ), f"CreateSession PeerKind = {payload.get('PeerKind')!r}, want system"
-    assert (
-        payload.get("PeerID") == agent.id
-    ), f"CreateSession PeerID = {payload.get('PeerID')!r}, want {agent.id!r}"
+    assert isinstance(payload, dict), (
+        f"CreateSession Payload missing: {create_session_body!r}"
+    )
+    assert payload.get("Channel") == "webchat", (
+        f"CreateSession Channel = {payload.get('Channel')!r}, want webchat"
+    )
+    assert payload.get("PeerKind") == "system", (
+        f"CreateSession PeerKind = {payload.get('PeerKind')!r}, want system"
+    )
+    assert payload.get("PeerID") == agent.id, (
+        f"CreateSession PeerID = {payload.get('PeerID')!r}, want {agent.id!r}"
+    )
 
     # Chat body verification — use the *batch* (last) Chat request which carries
     # the "批量" content; both chat calls go to the same Action so disambiguate
     # by indexing the last occurrence.
     last_chat_idx = len(actions) - 1 - actions[::-1].index("Chat")
     chat_body = json.loads(handler.calls[last_chat_idx].content)
-    assert (
-        chat_body.get("SessionID") == session.id
-    ), f"Chat SessionID = {chat_body.get('SessionID')!r}, want {session.id!r}"
-    assert (
-        chat_body.get("AgentID") == agent.id
-    ), f"Chat AgentID = {chat_body.get('AgentID')!r}, want {agent.id!r} (SDK should infer agent from session)"
+    assert chat_body.get("SessionID") == session.id, (
+        f"Chat SessionID = {chat_body.get('SessionID')!r}, want {session.id!r}"
+    )
+    assert chat_body.get("AgentID") == agent.id, (
+        f"Chat AgentID = {chat_body.get('AgentID')!r}, want {agent.id!r} (SDK should infer agent from session)"
+    )
     content = chat_body.get("Content", "")
-    assert (
-        "批量" in content
-    ), f"Chat Content = {content!r}, want contains '批量'"
+    assert "批量" in content, f"Chat Content = {content!r}, want contains '批量'"
+    assert chat_body.get("Approve") == "all"
+    assert chat_body.get("Stream") is False

--- a/libs/hibot/tests/test_models.py
+++ b/libs/hibot/tests/test_models.py
@@ -1,0 +1,97 @@
+"""Contract tests for model Actions hosted by hibot-server."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlsplit
+
+from hibot import V1ModelGetParams, V1ModelProviderGetParams, V1ModelProviderListParams
+
+
+def _action(request) -> str:
+    return parse_qs(urlsplit(str(request.url)).query)["Action"][0]
+
+
+def _version(request) -> str:
+    return parse_qs(urlsplit(str(request.url)).query)["Version"][0]
+
+
+def test_models_use_current_server_actions(client_factory, make_handler, ok_envelope):
+    handler = make_handler(
+        [
+            ok_envelope({"Items": [{"ID": "model-1", "Name": "demo"}], "Total": 1}),
+            ok_envelope({"Providers": ["openai"]}),
+            ok_envelope({"Models": [{"ID": "provider-1"}], "Total": 1}),
+            ok_envelope({"Items": [{"ID": "provider-1"}]}),
+        ]
+    )
+    client = client_factory(handler)
+
+    listing = client.v1.models.list(name="demo")
+    providers = client.v1.models.list_providers()
+    model_providers = client.v1.models.list_model_providers(V1ModelProviderListParams())
+    selected = client.v1.models.get_model_provider(
+        V1ModelProviderGetParams(ids=["provider-1"])
+    )
+
+    assert listing.items[0].id == "model-1"
+    assert providers == ["openai"]
+    assert model_providers.items[0].id == "provider-1"
+    assert selected[0].id == "provider-1"
+    assert [_action(req) for req in handler.calls] == [
+        "ListModels",
+        "ListProviders",
+        "ListModelProviders",
+        "GetModelProvider",
+    ]
+    for request in handler.calls:
+        assert _version(request) == "2026-04-23"
+        assert request.headers["x-top-service"] == "hibot-server"
+        assert json.loads(request.content)["WorkspaceID"] == "ws-1"
+
+
+def test_get_model_uses_server_action(client_factory, make_handler, ok_envelope):
+    handler = make_handler([ok_envelope({"Items": [{"ID": "model-1"}]})])
+    client = client_factory(handler)
+
+    model = client.v1.models.get(V1ModelGetParams(id="model-1"))
+
+    assert model.id == "model-1"
+    assert _action(handler.calls[0]) == "GetModel"
+    assert handler.calls[0].headers["x-top-service"] == "hibot-server"
+
+
+def test_get_model_by_model_name_scans_server_pages(
+    client_factory, make_handler, ok_envelope
+):
+    first_page = [
+        {"ID": f"model-{index}", "ModelName": f"other-{index}"} for index in range(100)
+    ]
+    handler = make_handler(
+        [
+            ok_envelope({"Items": first_page, "Total": 101}),
+            ok_envelope(
+                {
+                    "Items": [{"ID": "wanted", "ModelName": "target-model"}],
+                    "Total": 101,
+                }
+            ),
+        ]
+    )
+    client = client_factory(handler)
+
+    model = client.v1.models.get(V1ModelGetParams(model_name="target-model"))
+
+    assert model.id == "wanted"
+    assert [_action(request) for request in handler.calls] == [
+        "ListModels",
+        "ListModels",
+    ]
+    assert json.loads(handler.calls[0].content)["Page"] == {
+        "PageNum": 1,
+        "PageSize": 100,
+    }
+    assert json.loads(handler.calls[1].content)["Page"] == {
+        "PageNum": 2,
+        "PageSize": 100,
+    }

--- a/libs/hibot/tests/test_real_env.py
+++ b/libs/hibot/tests/test_real_env.py
@@ -11,12 +11,12 @@ import os
 import time
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import hibot
 import pytest
 from hibot import (
     V1AgentDeleteParams,
-    V1AgentListParams,
     V1AgentNewParams,
     V1AgentNewParamsToolUnion,
     V1ManagedAgentModelConfigParams,
@@ -26,19 +26,32 @@ from hibot import (
     V1ModelGetParams,
     V1ResourceDeleteParams,
     V1ResourceNewParams,
+    V1RunListParams,
     V1SessionChatParams,
+    V1SessionDeleteParams,
     V1SessionNewParams,
     V1SkillDeleteParams,
     V1SkillNewParams,
     V1UploadBlobParams,
 )
 
-_V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO = "doubao-seed-2.0-pro-260215"
+_V1_MANAGED_AGENT_MODEL_DOUBAO_SEED_PRO = "doubao-seed-2-0-pro-260215"
 _E2E_SKILL_PULSE_TOKEN = "PULSE_OK_E2E"
 
 _TESTDATA_DIR = Path(__file__).resolve().parents[1] / "testdata"
 _E2E_RESOURCE_FIXTURE = _TESTDATA_DIR / "runbook.md"
 _E2E_SKILL_FIXTURE_DIR = _TESTDATA_DIR / "skill"
+
+
+def _create_e2e_environment(client: hibot.Client) -> hibot.V1Environment:
+    image_type = _trim_env("HIBOT_E2E_ENV_IMAGE_TYPE") or "hermes"
+    env = client.v1.environments.create(
+        name=f"python-sdk-e2e-env-{time.time_ns()}",
+        description="Temporary environment created by the Python SDK E2E test.",
+        image_type=image_type,
+    )
+    print(f"created environment: id={env.id} image_type={env.image_type}")
+    return env
 
 
 def _trim_env(key: str) -> str:
@@ -48,7 +61,7 @@ def _trim_env(key: str) -> str:
 
 
 def _require_real_env_or_skip() -> str:
-    host = _trim_env("HIBOT_E2E_TOP_HOST")
+    host = _trim_env("HIBOT_E2E_TOP_HOST") or _trim_env("HIBOT_ENDPOINT")
     if not host:
         pytest.skip(
             "real-env tests require HIBOT_E2E_TOP_HOST; skipping in offline-only run"
@@ -57,9 +70,9 @@ def _require_real_env_or_skip() -> str:
 
 
 def _require_credentials() -> tuple[str, str, str]:
-    ak = _trim_env("HIBOT_E2E_AK")
-    sk = _trim_env("HIBOT_E2E_SK")
-    workspace = _trim_env("HIBOT_E2E_WORKSPACE")
+    ak = _trim_env("HIBOT_E2E_AK") or _trim_env("HIBOT_AK")
+    sk = _trim_env("HIBOT_E2E_SK") or _trim_env("HIBOT_SK")
+    workspace = _trim_env("HIBOT_E2E_WORKSPACE") or _trim_env("HIBOT_WORKSPACE_ID")
     if not ak or not sk or not workspace:
         pytest.fail(
             "real-env tests require HIBOT_E2E_AK / HIBOT_E2E_SK / HIBOT_E2E_WORKSPACE"
@@ -79,6 +92,67 @@ def _new_real_client() -> tuple[hibot.Client, str, str]:
         timeout=120.0,
     )
     return hibot.Hibot(cfg), host, workspace
+
+
+def _wait_agent_ready(
+    client: hibot.Client, agent_id: str, timeout_seconds: float = 600.0
+) -> hibot.V1Agent:
+    deadline = time.monotonic() + timeout_seconds
+    last_status = "missing"
+    previous_status = ""
+    while time.monotonic() < deadline:
+        agent = client.v1.agents.get(hibot.V1AgentGetParams(agent_id=agent_id))
+        status = agent.runtime_status
+        if status is not None:
+            last_status = (
+                f"status={status.status} ready={status.ready} "
+                f"reason={status.reason} message={status.message}"
+            )
+            if last_status != previous_status:
+                print(f"agent status: id={agent_id} {last_status}")
+                previous_status = last_status
+            if status.ready:
+                print(f"agent ready: id={agent_id} {last_status}")
+                return agent
+        time.sleep(5)
+    pytest.fail(f"agent {agent_id} did not become ready: {last_status}")
+
+
+def test_wait_agent_ready_tolerates_transient_runtime_error(monkeypatch):
+    """Match hibot_engine's waiter: controller errors may recover before timeout."""
+    agents = iter(
+        [
+            hibot.V1Agent(
+                id="agent-1",
+                runtime_status=hibot.V1AgentRuntimeStatus(
+                    status="error",
+                    ready=False,
+                    reason="Unschedulable",
+                    message="waiting for PVC",
+                ),
+            ),
+            hibot.V1Agent(
+                id="agent-1",
+                runtime_status=hibot.V1AgentRuntimeStatus(
+                    status="ready",
+                    ready=True,
+                ),
+            ),
+        ]
+    )
+    client = SimpleNamespace(
+        v1=SimpleNamespace(
+            agents=SimpleNamespace(get=lambda _params: next(agents)),
+        )
+    )
+    monotonic_values = iter([0.0, 1.0, 2.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    result = _wait_agent_ready(client, "agent-1", timeout_seconds=10.0)
+
+    assert result.runtime_status is not None
+    assert result.runtime_status.ready is True
 
 
 def _run_streaming_and_collect_events(
@@ -105,65 +179,126 @@ def _run_streaming_and_collect_events(
                     f"streaming chat failed: {event.error.message} (events={event_names})"
                 )
         if stream.err is not None:
-            pytest.fail(
-                f"streaming chat err: {stream.err} (events={event_names})"
-            )
+            pytest.fail(f"streaming chat err: {stream.err} (events={event_names})")
         if not saw_completed:
             pytest.fail(
                 f"streaming chat: no completed event observed (events={event_names})"
             )
         if not saw_delta:
-            print(
-                f"streaming chat: no delta event (short reply); events={event_names}"
-            )
+            print(f"streaming chat: no delta event (short reply); events={event_names}")
         final_msg = stream.final_message()
     return final_msg, event_names
 
 
+def test_real_env_server_read_smoke():
+    """Verify read-only actions are registered on hibot-server in the target deployment."""
+    client, _host, _workspace = _new_real_client()
+    try:
+        checks = {
+            "environments": client.v1.environments.list(),
+            "workspace_specs": client.v1.environments.list_workspace_specs(),
+            "models": client.v1.models.list().items,
+            "model_providers": client.v1.models.list_providers(),
+            "agents": client.v1.agents.list(),
+            "channels": client.v1.channels.list(),
+            "sessions": client.v1.sessions.list().items,
+            "cron_jobs": client.v1.cron_jobs.list().items,
+            "skills": client.v1.skills.list(),
+            "mcps": client.v1.mcps.list(),
+            "resources": client.v1.resources.list().items,
+            "directories": client.v1.resources.directories.list().items,
+            "memory_stores": client.v1.memories.list_stores().items,
+        }
+        overview = client.v1.overview.get()
+        if not checks["workspace_specs"]:
+            pytest.fail("real-env server smoke: workspace spec catalog is empty")
+        if overview.summary is None:
+            pytest.fail("real-env server smoke: overview response missing Summary")
+        print(
+            "server read smoke: "
+            + ", ".join(f"{name}={len(items)}" for name, items in checks.items())
+        )
+    finally:
+        client.close()
+
+
 def test_real_env_journey():
-    """Mirrors Go runRealEnvJourney — discover agent, chat streaming + batch."""
+    """Create an agent and verify server-backed streaming + synchronous Chat."""
     client, _host, workspace = _new_real_client()
-
-    # Step 1: discover an existing agent.
-    agents = client.v1.agents.list(V1AgentListParams())
-    if not agents:
-        pytest.fail(
-            f"real-env workspace {workspace!r} has no agents; please pre-create one before running this test"
+    cleanup_records: list[tuple[str, callable]] = []
+    try:
+        model = _resolve_real_env_model(client)
+        environment = _create_e2e_environment(client)
+        cleanup_records.append(
+            (
+                f"environment {environment.id}",
+                lambda: client.v1.environments.delete(env_id=environment.id),
+            )
         )
-    agent = agents[0]
-    print(f"using agent: id={agent.id} name={agent.name}")
-
-    # Step 2: create a session with no Peer — webchat default path.
-    session = client.v1.sessions.create(V1SessionNewParams(agent_id=agent.id))
-    if not session.id:
-        pytest.fail(f"real-env CreateSession returned empty ID: {session!r}")
-    print(f"created session: {session.id}")
-
-    # Step 3: streaming chat — must observe completed.
-    streaming_final, streaming_events = _run_streaming_and_collect_events(
-        client,
-        session.id,
-        agent.id,
-        "流式真实环境冒烟：请用一句话介绍你自己。",
-    )
-    if not streaming_final.id or not streaming_final.content:
-        pytest.fail(
-            f"real-env streaming final message incomplete: {streaming_final!r}"
+        agent = client.v1.agents.create(
+            V1AgentNewParams(
+                name=f"python-sdk-e2e-{time.time_ns()}",
+                model=V1ManagedAgentModelConfigParams(id=model.id),
+                system="You are a concise end-to-end test assistant.",
+                env_id=environment.id,
+            )
         )
-    print(
-        f"streaming final: id={streaming_final.id} content={streaming_final.content!r} events={streaming_events}"
-    )
+        cleanup_records.append(
+            (
+                f"agent {agent.id}",
+                lambda: client.v1.agents.delete(V1AgentDeleteParams(agent_id=agent.id)),
+            )
+        )
+        _wait_agent_ready(client, agent.id)
 
-    # Step 4: batch (non-streaming) chat reuses the same session.
-    batch_final = client.v1.sessions.chat(
-        session.id,
-        V1SessionChatParams(
-            agent_id=agent.id, input="批量真实环境冒烟：再回答一次同样的问题。"
-        ),
-    )
-    if not batch_final.id or not batch_final.content:
-        pytest.fail(f"real-env batch final message incomplete: {batch_final!r}")
-    print(f"batch final: id={batch_final.id} content={batch_final.content!r}")
+        session = client.v1.sessions.create(V1SessionNewParams(agent_id=agent.id))
+        cleanup_records.append(
+            (
+                f"session {session.id}",
+                lambda: client.v1.sessions.delete(
+                    V1SessionDeleteParams(session_id=session.id)
+                ),
+            )
+        )
+        print(f"created agent={agent.id} session={session.id} workspace={workspace}")
+
+        streaming_final, streaming_events = _run_streaming_and_collect_events(
+            client,
+            session.id,
+            agent.id,
+            "流式真实环境冒烟：请只回答 STREAM_OK。",
+        )
+        if not streaming_final.content:
+            pytest.fail(
+                f"real-env streaming final message incomplete: {streaming_final!r}"
+            )
+        print(
+            f"streaming final: content={streaming_final.content!r} events={streaming_events}"
+        )
+
+        batch_final = client.v1.sessions.chat(
+            session.id,
+            V1SessionChatParams(
+                agent_id=agent.id, input="非流式真实环境冒烟：请只回答 SYNC_OK。"
+            ),
+        )
+        if not batch_final.content:
+            pytest.fail(f"real-env sync final message incomplete: {batch_final!r}")
+        print(f"sync final: content={batch_final.content!r}")
+
+        runs = client.v1.runs.list(
+            V1RunListParams(agent_id=agent.id, session_id=session.id)
+        )
+        if not runs:
+            pytest.fail("real-env run read model is empty after completed Chat calls")
+        print(f"run read model: count={len(runs)} latest={runs[0].id}")
+    finally:
+        for label, cleanup in reversed(cleanup_records):
+            try:
+                cleanup()
+            except Exception as exc:  # noqa: BLE001
+                print(f"cleanup {label}: {exc}")
+        client.close()
 
 
 def _build_skill_zip_from_dir(src_dir: Path, out_path: Path) -> Path:
@@ -218,29 +353,6 @@ def _resolve_real_env_model(client: hibot.Client) -> V1Model:
 def test_real_env_resource_skill_loop(tmp_path):
     """Mirrors Go TestRealEnvResourceSkillLoop — full closed loop with cleanup."""
     client, _host, _workspace = _new_real_client()
-
-    # Step 1: pick a usable model.
-    model = _resolve_real_env_model(client)
-
-    # Step 2: upload Resource fixture.
-    resource_filename = _E2E_RESOURCE_FIXTURE.name
-    with open(_E2E_RESOURCE_FIXTURE, "rb") as f:
-        runbook_bytes = f.read()
-    resource_blob = client.v1.uploads.upload_blob(
-        V1UploadBlobParams(filename=resource_filename, content_type="text/markdown"),
-        runbook_bytes,
-    )
-    if not resource_blob.blob_id:
-        pytest.fail(f"upload {resource_filename}: empty BlobID")
-    resource = client.v1.resources.create(
-        V1ResourceNewParams(
-            name=f"e2e-runbook-{time.time_ns()}",
-            type="document_collection",
-            blob_id=resource_blob.blob_id,
-        )
-    )
-    print(f"created resource: id={resource.id} name={resource.name}")
-
     keep_agent = bool(_trim_env("HIBOT_E2E_KEEP_AGENT"))
     cleanup_records: list[tuple[str, callable]] = []
 
@@ -254,6 +366,38 @@ def test_real_env_resource_skill_loop(tmp_path):
                 print(f"cleanup {label}: {exc}")
 
     try:
+        # Step 1: pick a usable model.
+        model = _resolve_real_env_model(client)
+
+        environment = _create_e2e_environment(client)
+        cleanup_records.append(
+            (
+                f"environment {environment.id}",
+                lambda: client.v1.environments.delete(env_id=environment.id),
+            )
+        )
+
+        # Step 2: upload Resource fixture.
+        resource_filename = _E2E_RESOURCE_FIXTURE.name
+        with open(_E2E_RESOURCE_FIXTURE, "rb") as f:
+            runbook_bytes = f.read()
+        resource_blob = client.v1.uploads.upload_blob(
+            V1UploadBlobParams(
+                filename=resource_filename,
+                content_type="text/markdown",
+            ),
+            runbook_bytes,
+        )
+        if not resource_blob.blob_id:
+            pytest.fail(f"upload {resource_filename}: empty BlobID")
+        resource = client.v1.resources.create(
+            V1ResourceNewParams(
+                name=f"e2e-runbook-{time.time_ns()}",
+                type="document_collection",
+                blob_id=resource_blob.blob_id,
+            )
+        )
+        print(f"created resource: id={resource.id} name={resource.name}")
         cleanup_records.append(
             (
                 f"resource {resource.id}",
@@ -315,6 +459,7 @@ def test_real_env_resource_skill_loop(tmp_path):
                     )
                 ],
                 resources=[V1ManagedAgentResourceRefParams(id=resource.id)],
+                env_id=environment.id,
             )
         )
         if not agent.id:
@@ -323,17 +468,24 @@ def test_real_env_resource_skill_loop(tmp_path):
         cleanup_records.append(
             (
                 f"agent {agent.id}",
-                lambda: client.v1.agents.delete(
-                    V1AgentDeleteParams(agent_id=agent.id)
-                ),
+                lambda: client.v1.agents.delete(V1AgentDeleteParams(agent_id=agent.id)),
             )
         )
+        _wait_agent_ready(client, agent.id)
 
         # Step 5: create session.
         session = client.v1.sessions.create(V1SessionNewParams(agent_id=agent.id))
         if not session.id:
             pytest.fail("create session: empty ID")
         print(f"created session: {session.id}")
+        cleanup_records.append(
+            (
+                f"session {session.id}",
+                lambda: client.v1.sessions.delete(
+                    V1SessionDeleteParams(session_id=session.id)
+                ),
+            )
+        )
 
         # Step 6: skill closed loop — trigger pulse check, must observe tool events.
         skill_final, skill_events = _run_streaming_and_collect_events(
@@ -342,9 +494,7 @@ def test_real_env_resource_skill_loop(tmp_path):
             agent.id,
             "请执行一次 pulse check（按照 e2e-runbook-skill 的契约调用工具），并把工具返回的 token 原样告诉我。",
         )
-        print(
-            f"skill loop events={skill_events} final={skill_final.content!r}"
-        )
+        print(f"skill loop events={skill_events} final={skill_final.content!r}")
         content = skill_final.content or ""
         if _E2E_SKILL_PULSE_TOKEN not in content:
             pytest.fail(
@@ -352,9 +502,7 @@ def test_real_env_resource_skill_loop(tmp_path):
                 f"system prompt no longer leaks the token, so this proves the skill was NOT invoked. "
                 f"got={content!r}"
             )
-        if not any(
-            ev in ("tool_start", "tool_complete") for ev in skill_events
-        ):
+        if not any(ev in ("tool_start", "tool_complete") for ev in skill_events):
             pytest.fail(
                 "skill loop: no tool_start/tool_complete event observed on SSE stream; "
                 "the model likely answered without actually invoking e2e-runbook-skill. "
@@ -365,3 +513,4 @@ def test_real_env_resource_skill_loop(tmp_path):
         )
     finally:
         _cleanup()
+        client.close()

--- a/libs/hibot/tests/test_server_services.py
+++ b/libs/hibot/tests/test_server_services.py
@@ -1,0 +1,458 @@
+"""Contract tests for hibot-server capabilities added after the initial SDK."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+from hibot import (
+    V1ArkSkillHubGetParams,
+    V1ArkSkillHubImportParams,
+    V1ArkSkillHubListParams,
+    V1ChannelDeleteParams,
+    V1ChannelGetParams,
+    V1ChannelListParams,
+    V1ChannelNewParams,
+    V1ChannelUpdateParams,
+    V1CronJobDeleteParams,
+    V1CronJobGetParams,
+    V1CronJobListParams,
+    V1CronJobNewParams,
+    V1CronJobRunListParams,
+    V1CronJobRunNowParams,
+    V1CronJobRunSyncListParams,
+    V1CronJobToggleParams,
+    V1CronJobUpdateParams,
+    V1MCPBatchGetParams,
+    V1MemoryFileDeleteParams,
+    V1MemoryFileGetParams,
+    V1MemoryFileListParams,
+    V1MemoryFileSearchParams,
+    V1MemoryFileUpsertParams,
+    V1MemoryStoreDeleteParams,
+    V1MemoryStoreGetParams,
+    V1MemoryStoreListParams,
+    V1MemoryStoreNewParams,
+    V1MemoryStoreUpdateParams,
+    V1MetricAggregatorParams,
+    V1MetricBreakdownParams,
+    V1MetricOverviewParams,
+    V1MetricTopKParams,
+    V1MetricTrendParams,
+    V1ResourceBatchCreateItemParams,
+    V1ResourceBatchCreateParams,
+    V1ResourceMoveParams,
+    V1RunGetParams,
+    V1RunListParams,
+    V1RuntimeAPIKeyDeleteParams,
+    V1RuntimeAPIKeyGetParams,
+    V1RuntimeAPIKeyListParams,
+    V1RuntimeAPIKeyNewParams,
+    V1RuntimeAPIKeyUpdateParams,
+    V1RuntimeAPIKeyUserInfoParams,
+    V1SkillBatchGetParams,
+    V1SkillParseParams,
+    V1SpanGetParams,
+    V1SpanListParams,
+    V1TraceListParams,
+)
+
+
+def _action(req: httpx.Request) -> str:
+    return parse_qs(urlsplit(str(req.url)).query).get("Action", [""])[0]
+
+
+def _assert_server_calls(calls) -> None:
+    for req in calls:
+        query = parse_qs(urlsplit(str(req.url)).query)
+        assert query["Version"] == ["2026-04-23"]
+        assert req.headers["x-top-service"] == "hibot-server"
+
+
+def test_existing_resource_services_cover_new_server_actions(
+    client_factory, make_handler, ok_envelope
+):
+    handler = make_handler(
+        [
+            ok_envelope({"Name": "demo", "BlobID": "blob-1"}),
+            ok_envelope({"Items": [{"Slug": "demo", "Name": "Demo"}]}),
+            ok_envelope({"Skill": {"Slug": "demo", "Name": "Demo"}}),
+            ok_envelope({"Name": "Demo", "BlobID": "blob-2"}),
+            ok_envelope({"Items": [{"ID": "skill-1"}]}),
+            ok_envelope({"Items": [{"ID": "mcp-1"}]}),
+            ok_envelope({"Items": [{"ID": "resource-1"}]}),
+            ok_envelope({}),
+        ]
+    )
+    client = client_factory(handler)
+
+    parsed = client.v1.skills.parse(V1SkillParseParams(blob_id="blob-1"))
+    hub = client.v1.skills.list_ark_skill_hub(V1ArkSkillHubListParams())
+    detail = client.v1.skills.get_ark_skill_hub(V1ArkSkillHubGetParams(slug="demo"))
+    imported = client.v1.skills.import_ark_skill_hub(
+        V1ArkSkillHubImportParams(slug="demo")
+    )
+    skills = client.v1.skills.batch_get(V1SkillBatchGetParams(ids=["skill-1"]))
+    mcps = client.v1.mcps.batch_get(V1MCPBatchGetParams(ids=["mcp-1"]))
+    resources = client.v1.resources.batch_create(
+        V1ResourceBatchCreateParams(
+            items=[V1ResourceBatchCreateItemParams(name="runbook", blob_id="blob-3")]
+        )
+    )
+    client.v1.resources.move(
+        V1ResourceMoveParams(
+            resource_id="resource-1",
+            old_directory_id="old",
+            new_directory_id="new",
+        )
+    )
+
+    assert parsed.name == "demo"
+    assert hub.items[0].slug == "demo"
+    assert detail.slug == "demo"
+    assert imported.blob_id == "blob-2"
+    assert skills[0].id == "skill-1"
+    assert mcps[0].id == "mcp-1"
+    assert resources[0].id == "resource-1"
+    assert [_action(req) for req in handler.calls] == [
+        "ParseSkill",
+        "ListArkSkillHubSkills",
+        "GetArkSkillHubSkill",
+        "ImportArkSkillHubSkill",
+        "BatchGetSkills",
+        "BatchGetMCPs",
+        "BatchCreateResources",
+        "MoveResource",
+    ]
+    assert json.loads(handler.calls[6].content)["Items"] == [
+        {"Name": "runbook", "BlobID": "blob-3"}
+    ]
+    _assert_server_calls(handler.calls)
+
+
+def test_channels_runtime_api_keys_and_runs(client_factory, make_handler, ok_envelope):
+    handler = make_handler(
+        [
+            ok_envelope({"ID": "channel-1"}),
+            ok_envelope({"Items": [{"ID": "channel-1"}]}),
+            ok_envelope({"ID": "channel-1", "Name": "web"}),
+            ok_envelope({}),
+            ok_envelope({}),
+            ok_envelope(
+                {
+                    "Item": {"ID": "key-1", "AgentID": "agent-1"},
+                    "RawKey": "raw-once",
+                }
+            ),
+            ok_envelope({"Items": [{"ID": "key-1"}]}),
+            ok_envelope({"RawKey": "raw-revealed"}),
+            ok_envelope({}),
+            ok_envelope({}),
+            ok_envelope({"Items": [{"ID": "run-1"}]}),
+            ok_envelope({"ID": "run-1", "Status": "succeeded"}),
+        ]
+    )
+    client = client_factory(handler)
+
+    channel = client.v1.channels.create(
+        V1ChannelNewParams(agent_id="agent-1", name="web")
+    )
+    channels = client.v1.channels.list(V1ChannelListParams(agent_id="agent-1"))
+    detail = client.v1.channels.get(V1ChannelGetParams(channel_id="channel-1"))
+    client.v1.channels.update(
+        V1ChannelUpdateParams(channel_id="channel-1", name="renamed")
+    )
+    client.v1.channels.delete(V1ChannelDeleteParams(channel_id="channel-1"))
+
+    created_key = client.v1.runtime_api_keys.create(
+        V1RuntimeAPIKeyNewParams(agent_id="agent-1", expired="30d")
+    )
+    keys = client.v1.runtime_api_keys.list(
+        V1RuntimeAPIKeyListParams(agent_id="agent-1")
+    )
+    raw_key = client.v1.runtime_api_keys.reveal(
+        V1RuntimeAPIKeyGetParams(
+            agent_id="agent-1",
+            id="key-1",
+            user_info=V1RuntimeAPIKeyUserInfoParams(
+                user_name="tester",
+                password="password",
+            ),
+        )
+    )
+    client.v1.runtime_api_keys.update(
+        V1RuntimeAPIKeyUpdateParams(
+            agent_id="agent-1",
+            id="key-1",
+            description="rotated",
+        )
+    )
+    client.v1.runtime_api_keys.delete(
+        V1RuntimeAPIKeyDeleteParams(agent_id="agent-1", id="key-1")
+    )
+    runs = client.v1.runs.list(V1RunListParams(agent_id="agent-1"))
+    run = client.v1.runs.get(V1RunGetParams(run_id="run-1"))
+
+    assert channel.id == channels[0].id == detail.id == "channel-1"
+    assert created_key.item is not None
+    assert created_key.item.id == "key-1"
+    assert created_key.raw_key == "raw-once"
+    assert keys[0].id == "key-1"
+    assert raw_key == "raw-revealed"
+    assert runs[0].id == run.id == "run-1"
+    assert [_action(req) for req in handler.calls] == [
+        "CreateChannel",
+        "ListChannels",
+        "GetChannel",
+        "UpdateChannel",
+        "DeleteChannel",
+        "CreateRuntimeAPIKey",
+        "ListRuntimeAPIKeys",
+        "GetRuntimeAPIKey",
+        "UpdateRuntimeAPIKey",
+        "DeleteRuntimeAPIKey",
+        "ListRuns",
+        "GetRun",
+    ]
+    _assert_server_calls(handler.calls)
+
+
+def test_cron_job_server_actions(client_factory, make_handler, ok_envelope):
+    handler = make_handler(
+        [
+            ok_envelope({"Items": [{"ID": "cron-1"}], "Page": {"Total": 1}}),
+            ok_envelope({"Items": [{"Status": "succeeded"}]}),
+            ok_envelope(
+                {
+                    "Items": [{"ID": "run-1", "CronJobID": "cron-1"}],
+                    "NextCursorUpdatedAt": "100",
+                    "NextCursorID": "run-1",
+                }
+            ),
+            ok_envelope({"ID": "cron-1", "Name": "daily"}),
+            ok_envelope({"CronJobID": "cron-2", "NextRunAt": "tomorrow"}),
+            ok_envelope({}),
+            ok_envelope({}),
+            ok_envelope({"ID": "cron-1", "Enabled": False}),
+            ok_envelope(
+                {
+                    "CronJobID": "cron-1",
+                    "Status": "pending",
+                    "TriggerType": "manual",
+                }
+            ),
+        ]
+    )
+    client = client_factory(handler)
+
+    listing = client.v1.cron_jobs.list(V1CronJobListParams(enabled=True))
+    run_listing = client.v1.cron_jobs.list_runs(
+        V1CronJobRunListParams(cron_job_id="cron-1")
+    )
+    sync_listing = client.v1.cron_jobs.list_runs_for_sync(
+        V1CronJobRunSyncListParams(cursor_updated_at="0")
+    )
+    detail = client.v1.cron_jobs.get(V1CronJobGetParams(cron_job_id="cron-1"))
+    created = client.v1.cron_jobs.create(
+        V1CronJobNewParams(
+            agent_id="agent-1",
+            name="daily",
+            prompt="summarize",
+            schedule_type="cron",
+            schedule_value="0 9 * * *",
+            delivery_channel="webchat",
+            delivery_to="user-1",
+        )
+    )
+    client.v1.cron_jobs.update(
+        V1CronJobUpdateParams(cron_job_id="cron-1", prompt="new prompt")
+    )
+    client.v1.cron_jobs.delete(V1CronJobDeleteParams(cron_job_id="cron-2"))
+    toggled = client.v1.cron_jobs.toggle(
+        V1CronJobToggleParams(cron_job_id="cron-1", enabled=False)
+    )
+    triggered = client.v1.cron_jobs.run_now(V1CronJobRunNowParams(cron_job_id="cron-1"))
+
+    assert listing.items[0].id == detail.id == "cron-1"
+    assert run_listing.items[0].status == "succeeded"
+    assert sync_listing.items[0].id == "run-1"
+    assert sync_listing.next_cursor_id == "run-1"
+    assert created.cron_job_id == "cron-2"
+    assert toggled.enabled is False
+    assert triggered.trigger_type == "manual"
+    assert [_action(req) for req in handler.calls] == [
+        "ListCronJobs",
+        "ListCronJobRuns",
+        "ListCronJobRunsForSync",
+        "GetCronJob",
+        "CreateCronJob",
+        "UpdateCronJob",
+        "DeleteCronJob",
+        "ToggleCronJob",
+        "RunCronJobNow",
+    ]
+    _assert_server_calls(handler.calls)
+
+
+def test_observation_metrics_overview_and_memory_actions(
+    client_factory, make_handler, ok_envelope
+):
+    handler = make_handler(
+        [
+            ok_envelope({"Items": [{"TraceID": "trace-1"}], "Total": 1}),
+            ok_envelope({"Items": [{"SpanID": "span-1"}], "Total": 1}),
+            ok_envelope({"Span": {"TraceID": "trace-1", "SpanID": "span-1"}}),
+            ok_envelope({"Summary": {"AgentTotal": 1}}),
+            ok_envelope(
+                {
+                    "Data": {"RequestCount": 3, "SuccessRate": 1.0},
+                    "EffectiveStepSeconds": 60,
+                }
+            ),
+            ok_envelope(
+                {
+                    "Series": [{"Time": "2026-01-01T00:00:00Z", "Value": 3}],
+                    "EffectiveStepSeconds": 60,
+                }
+            ),
+            ok_envelope(
+                {
+                    "Items": [{"Group": "agent-1", "Value": 3}],
+                    "EffectiveLimit": 5,
+                }
+            ),
+            ok_envelope(
+                {
+                    "Groups": [
+                        {
+                            "Group": "succeeded",
+                            "Points": [{"Time": "2026-01-01T00:00:00Z", "Value": 3}],
+                        }
+                    ],
+                    "EffectiveStepSeconds": 60,
+                }
+            ),
+            ok_envelope({"ID": "store-1"}),
+            ok_envelope({"Items": [{"ID": "store-1"}], "Page": {"Total": 1}}),
+            ok_envelope({"ID": "store-1", "Alias": "project"}),
+            ok_envelope({}),
+            ok_envelope({}),
+            ok_envelope({"Items": [{"ID": "file-1"}], "Page": {"Total": 1}}),
+            ok_envelope({"Items": [{"ID": "file-1"}], "Page": {"Total": 1}}),
+            ok_envelope({"ID": "file-1", "Path": "/notes.md"}),
+            ok_envelope(
+                {
+                    "FileID": "file-1",
+                    "Path": "/notes.md",
+                    "ContentSha256": "sha",
+                    "Revision": 1,
+                }
+            ),
+            ok_envelope({}),
+        ]
+    )
+    client = client_factory(handler)
+
+    traces = client.v1.observations.list_traces(
+        V1TraceListParams(session_id="session-1")
+    )
+    spans = client.v1.observations.list_trace_spans(
+        V1SpanListParams(trace_id="trace-1")
+    )
+    span = client.v1.observations.get_span_detail(
+        V1SpanGetParams(trace_id="trace-1", span_id="span-1")
+    )
+    overview = client.v1.overview.get()
+
+    aggregator = V1MetricAggregatorParams(
+        start_time="2026-01-01T00:00:00Z",
+        end_time="2026-01-01T01:00:00Z",
+    )
+    metric_overview = client.v1.metrics.overview(
+        V1MetricOverviewParams(aggregator=aggregator)
+    )
+    trend = client.v1.metrics.trend(
+        V1MetricTrendParams(metric="chat_request", aggregator=aggregator)
+    )
+    top_k = client.v1.metrics.top_k(
+        V1MetricTopKParams(
+            metric="chat_request",
+            group_by="agent",
+            aggregator=aggregator,
+            limit=5,
+        )
+    )
+    breakdown = client.v1.metrics.breakdown(
+        V1MetricBreakdownParams(
+            metric="chat_request",
+            group_by="status",
+            aggregator=aggregator,
+        )
+    )
+
+    store = client.v1.memories.create_store(
+        V1MemoryStoreNewParams(
+            name="Project",
+            alias="project",
+            description="Shared project memory",
+        )
+    )
+    stores = client.v1.memories.list_stores(V1MemoryStoreListParams())
+    store_detail = client.v1.memories.get_store(
+        V1MemoryStoreGetParams(store_id="store-1")
+    )
+    client.v1.memories.update_store(
+        V1MemoryStoreUpdateParams(store_id="store-1", description="Updated")
+    )
+    client.v1.memories.delete_store(V1MemoryStoreDeleteParams(store_id="store-2"))
+    files = client.v1.memories.list_files(V1MemoryFileListParams(store_id="store-1"))
+    searched = client.v1.memories.search_files(
+        V1MemoryFileSearchParams(store_id="store-1", keyword="notes")
+    )
+    file_detail = client.v1.memories.get_file(
+        V1MemoryFileGetParams(store_id="store-1", path="/notes.md")
+    )
+    upserted = client.v1.memories.upsert_file(
+        V1MemoryFileUpsertParams(
+            store_id="store-1",
+            path="/notes.md",
+            content="hello",
+        )
+    )
+    client.v1.memories.delete_file(
+        V1MemoryFileDeleteParams(store_id="store-1", path="/notes.md")
+    )
+
+    assert traces.items[0].trace_id == "trace-1"
+    assert spans.items[0].span_id == span.span_id == "span-1"
+    assert overview.summary["AgentTotal"] == 1
+    assert metric_overview.data is not None
+    assert metric_overview.data.request_count == 3
+    assert trend.series is not None and trend.series[0].value == 3
+    assert top_k.items[0].group == "agent-1"
+    assert breakdown.groups[0].points[0].value == 3
+    assert store.id == stores.items[0].id == store_detail.id == "store-1"
+    assert files.items[0].id == searched.items[0].id == file_detail.id == "file-1"
+    assert upserted.file_id == "file-1"
+    assert [_action(req) for req in handler.calls] == [
+        "ListTraces",
+        "ListTraceSpans",
+        "GetSpanDetail",
+        "GetOverview",
+        "GetMetricOverview",
+        "GetMetricTrend",
+        "GetMetricTopK",
+        "GetMetricBreakdown",
+        "CreateMemoryStore",
+        "ListMemoryStores",
+        "GetMemoryStore",
+        "UpdateMemoryStore",
+        "DeleteMemoryStore",
+        "ListMemoryFiles",
+        "SearchMemoryFiles",
+        "GetMemoryFile",
+        "UpsertMemoryFile",
+        "DeleteMemoryFile",
+    ]
+    _assert_server_calls(handler.calls)

--- a/libs/hibot/tests/test_sessions.py
+++ b/libs/hibot/tests/test_sessions.py
@@ -8,8 +8,14 @@ from urllib.parse import parse_qs, urlsplit
 import httpx
 import pytest
 from hibot import (
+    V1ChatApproveParams,
+    V1ChatCancelRunParams,
+    V1ChatResumeParams,
+    V1MessageListParams,
+    V1SessionBatchGetParams,
     V1SessionChatParams,
     V1SessionDeleteParams,
+    V1SessionListParams,
     V1SessionNewParams,
     V1SessionPeerParams,
 )
@@ -36,16 +42,10 @@ def test_create_session_injects_default_peer(client_factory, make_handler, ok_en
     assert body["AgentID"] == "agent-1"
     assert body["WorkspaceID"] == "ws-1"
     payload = body["Payload"]
-    # ConversationID 由 SDK 自动生成（仅 webchat 渠道）；逐字段断言其余 peer
-    # 默认值，避免与自动注入的 ConversationID 互相干扰。
     assert payload["Channel"] == "webchat"
     assert payload["PeerKind"] == "system"
     assert payload["PeerID"] == "agent-1"
-    cid = payload["ConversationID"]
-    assert isinstance(cid, str) and 1 <= len(cid) <= 64
-    import re
-
-    assert re.fullmatch(r"[A-Za-z0-9_-]+", cid)
+    assert "ConversationID" not in payload
 
 
 def test_create_session_with_explicit_peer_overrides_kind_and_id(
@@ -64,8 +64,7 @@ def test_create_session_with_explicit_peer_overrides_kind_and_id(
     assert payload["Channel"] == "webchat"
     assert payload["PeerKind"] == "user"
     assert payload["PeerID"] == "u-77"
-    # webchat 渠道下仍会自动注入 ConversationID。
-    assert "ConversationID" in payload
+    assert "ConversationID" not in payload
 
 
 def test_create_session_with_im_channel_passes_through(
@@ -90,61 +89,61 @@ def test_create_session_with_im_channel_passes_through(
     }
 
 
-def test_create_session_conversation_ids_are_unique(
+def test_create_session_passes_explicit_conversation_identity(
     client_factory, make_handler, ok_envelope
 ):
-    handler = make_handler(
-        [ok_envelope({"ID": "s-1"}), ok_envelope({"ID": "s-2"})]
-    )
+    handler = make_handler([ok_envelope({"ID": "s-1"})])
     client = client_factory(handler)
-    client.v1.sessions.create(V1SessionNewParams(agent_id="agent-1"))
-    client.v1.sessions.create(V1SessionNewParams(agent_id="agent-1"))
-    cid1 = json.loads(handler.calls[0].content)["Payload"]["ConversationID"]
-    cid2 = json.loads(handler.calls[1].content)["Payload"]["ConversationID"]
-    assert cid1 != cid2
+    client.v1.sessions.create(
+        V1SessionNewParams(
+            agent_id="agent-1",
+            conversation_id="conversation-1",
+            session_key="agent:agent-1:webchat:user:user-1:conv:conversation-1",
+            peer=V1SessionPeerParams(peer_kind="user", peer_id="user-1"),
+        )
+    )
+    payload = json.loads(handler.calls[0].content)["Payload"]
+    assert payload["ConversationID"] == "conversation-1"
+    assert payload["SessionKey"].endswith(":conv:conversation-1")
 
 
-def test_chat_uses_remembered_agent_id_and_routes_to_gateway(
+def test_chat_uses_remembered_agent_id_and_routes_to_server(
     client_factory, make_handler, ok_envelope, sse
 ):
-    sse_body = (
-        b'event: message_delta\n'
-        b'data: {"text":"hel"}\n\n'
-        b'event: message_delta\n'
-        b'data: {"text":"lo"}\n\n'
-        b'event: run_completed\n'
-        b'data: {"message":{"ID":"m-9","Role":"assistant","Content":"hello"}}\n\n'
-    )
     create_reply = ok_envelope({"ID": "s-1"})
-    chat_reply = sse(sse_body)
+    chat_reply = ok_envelope({"Message": "hello", "TokenCount": 2})
     handler = make_handler([create_reply, chat_reply])
     client = client_factory(handler)
 
     session = client.v1.sessions.create(V1SessionNewParams(agent_id="agent-1"))
     msg = client.v1.sessions.chat(session.id, V1SessionChatParams(input="hi"))
-    assert msg.id == "m-9"
+    assert msg.id is None
     assert msg.content == "hello"
+    assert msg.token_count == 2
 
     chat_req = handler.calls[1]
     assert _action(chat_req) == "Chat"
-    assert _version(chat_req) == "2026-05-11"
+    assert _version(chat_req) == "2026-04-23"
+    assert chat_req.headers["x-top-service"] == "hibot-server"
     body = json.loads(chat_req.content)
     # AgentID resolved from internal map (was not provided in params)
     assert body["AgentID"] == "agent-1"
     assert body["SessionID"] == "s-1"
     assert body["Content"] == "hi"
     assert body["WorkspaceID"] == "ws-1"
+    assert body["Approve"] == "all"
+    assert body["Stream"] is False
 
 
 def test_chat_streaming_yields_events_in_order(
     client_factory, make_handler, ok_envelope, sse
 ):
     sse_body = (
-        b'event: message_delta\n'
+        b"event: message_delta\n"
         b'data: {"text":"a"}\n\n'
-        b'event: message_delta\n'
+        b"event: message_delta\n"
         b'data: {"text":"b"}\n\n'
-        b'event: run_completed\n'
+        b"event: run_completed\n"
         b'data: {"message":{"ID":"m-1","Content":"ab"}}\n\n'
     )
     handler = make_handler(
@@ -166,9 +165,140 @@ def test_chat_streaming_yields_events_in_order(
 
     assert events == [("delta", "a"), ("delta", "b"), ("completed", "")]
     assert final.id == "m-1"
+    chat_req = handler.calls[1]
+    assert _version(chat_req) == "2026-04-23"
+    assert chat_req.headers["x-top-service"] == "hibot-server"
+    assert json.loads(chat_req.content)["Stream"] is True
 
 
-def test_chat_streaming_propagates_http_error(client_factory, make_handler, ok_envelope, sse):
+def test_chat_resolves_agent_id_from_server_for_unknown_session(
+    client_factory, make_handler, ok_envelope
+):
+    handler = make_handler(
+        [
+            ok_envelope({"ID": "s-existing", "AgentID": "agent-from-server"}),
+            ok_envelope({"Message": "ok"}),
+        ]
+    )
+    client = client_factory(handler)
+
+    msg = client.v1.sessions.chat("s-existing", V1SessionChatParams(input="hello"))
+
+    assert msg.content == "ok"
+    assert [_action(req) for req in handler.calls] == ["GetSession", "Chat"]
+    assert json.loads(handler.calls[1].content)["AgentID"] == "agent-from-server"
+
+
+def test_current_session_query_and_timeline_contract(
+    client_factory, make_handler, ok_envelope
+):
+    handler = make_handler(
+        [
+            ok_envelope({"Items": [{"ID": "s-1"}]}),
+            ok_envelope({"Items": [{"ID": "s-2"}]}),
+            ok_envelope(
+                {
+                    "Items": [{"ID": "m-1", "Content": "hello"}],
+                    "ResumeHint": {
+                        "RunID": "run-1",
+                        "RequestID": "request-1",
+                        "Status": "running",
+                    },
+                }
+            ),
+        ]
+    )
+    client = client_factory(handler)
+
+    listed = client.v1.sessions.list(
+        V1SessionListParams(session_keys=["key-1"], user_id="user-1")
+    )
+    batched = client.v1.sessions.batch_get(V1SessionBatchGetParams(session_ids=["s-2"]))
+    messages = client.v1.sessions.list_messages(
+        V1MessageListParams(
+            session_id="s-1",
+            display_mode="timeline",
+            base_message_id="m-2",
+        )
+    )
+
+    assert listed.items[0].id == "s-1"
+    assert batched.items[0].id == "s-2"
+    assert messages.resume_hint is not None
+    assert messages.resume_hint.run_id == "run-1"
+    assert messages.resume_hint.status == "running"
+    assert [_action(req) for req in handler.calls] == [
+        "ListSessions",
+        "BatchGetSessions",
+        "ListMessages",
+    ]
+    list_body = json.loads(handler.calls[0].content)
+    assert list_body["SessionKeys"] == ["key-1"]
+    assert list_body["UserID"] == "user-1"
+    batch_body = json.loads(handler.calls[1].content)
+    assert batch_body["SessionIDs"] == ["s-2"]
+    message_body = json.loads(handler.calls[2].content)
+    assert message_body["DisplayMode"] == "timeline"
+    assert message_body["BaseMessageID"] == "m-2"
+
+
+def test_chat_resume_approve_and_cancel_route_to_server(
+    client_factory, make_handler, ok_envelope, sse
+):
+    handler = make_handler(
+        [
+            sse(b'event: run_completed\ndata: {"message":{"ID":"m-1"}}\n\n'),
+            ok_envelope({"Accepted": True}),
+            ok_envelope({"Accepted": False}),
+        ]
+    )
+    client = client_factory(handler)
+
+    with client.v1.sessions.chat_resume(
+        V1ChatResumeParams(
+            session_id="s-1",
+            agent_id="agent-1",
+            run_id="run-1",
+            last_event_id="run-1:3",
+            approve="all",
+        )
+    ) as stream:
+        assert [event.type for event in stream] == ["completed"]
+    approved = client.v1.sessions.approve(
+        V1ChatApproveParams(
+            session_id="s-1",
+            run_id="run-1",
+            approval_request_id="approval-1",
+            choice_id="once",
+        )
+    )
+    cancelled = client.v1.sessions.cancel_run(
+        V1ChatCancelRunParams(
+            session_id="s-1",
+            run_id="run-1",
+            reason="user requested",
+        )
+    )
+
+    assert approved.accepted is True
+    assert cancelled.accepted is False
+    assert [_action(req) for req in handler.calls] == [
+        "ChatResume",
+        "Approve",
+        "CancelRun",
+    ]
+    for req in handler.calls:
+        assert _version(req) == "2026-04-23"
+        assert req.headers["x-top-service"] == "hibot-server"
+    resume_body = json.loads(handler.calls[0].content)
+    assert resume_body["RunID"] == "run-1"
+    assert resume_body["LastEventID"] == "run-1:3"
+    assert resume_body["Approve"] == "all"
+
+
+def test_chat_streaming_propagates_http_error(
+    client_factory, make_handler, ok_envelope, sse
+):
     handler = make_handler(
         [
             ok_envelope({"ID": "s-1"}),

--- a/libs/hibot/tests/test_sse.py
+++ b/libs/hibot/tests/test_sse.py
@@ -96,6 +96,21 @@ def test_decode_chat_event_extracts_failed_error():
     assert event.error.message == "explode"
 
 
+def test_decode_chat_event_extracts_server_failed_content():
+    data = json.dumps(
+        {
+            "content": "runtime provider error",
+            "request_id": "request-1",
+            "run_id": "run-1",
+            "status": "failed",
+        }
+    )
+    event = decode_chat_event("run_failed", data)
+    assert event.type == V1_SESSION_CHAT_EVENT_FAILED
+    assert event.request_id == "request-1"
+    assert event.error.message == "runtime provider error"
+
+
 def test_decode_chat_event_falls_back_to_top_level_message_id():
     data = json.dumps({"message_id": "m-2", "content": "fallback"})
     event = decode_chat_event("completed", data)


### PR DESCRIPTION
## Summary

- route every Hibot Action through `hibot-server` at API version `2026-04-23`; keep artifact uploads on the separate `up` service
- align the Python SDK surface with all 112 methods currently declared in `hibot_engine/api/idl/server.thrift`
- add Channel, CronJob, Memory, Metric, Observation, Overview, Run, and Runtime API Key services
- align Agent, Environment, Model, MCP, Resource, Session, Skill, and Chat request/response fields with the current server contracts
- support synchronous Chat plus streaming Chat, resume, approval, cancellation, and current server SSE failure payloads
- add contract tests, real-environment tests with cleanup, and updated SDK documentation

## Validation

- `uv run ruff check libs/hibot/hibot libs/hibot/tests`
- `uv run pytest libs/hibot/tests -o addopts= -q -ra` — 53 passed, 3 real-environment tests skipped without credentials
- `uv build --package hibot` — sdist and wheel built successfully
- real read-only Server smoke passed against the target deployment, covering Environment, WorkspaceSpec, Model, ModelProvider, Agent, Channel, Session, CronJob, Skill, MCP, Resource, Directory, MemoryStore, and Overview APIs
- live Chat reached `message_received` and `run_started`, proving Session/Chat Server routing; it then terminated with `runtime provider error`, and the temporary Session was deleted

## Known external runtime issue

Newly created Agents in the supplied deployment do not currently reach `RuntimeStatus.Ready`; observed runtime states include `PodNotReady` and `CrashLoopBackOff`. This prevents a successful `completed` Chat event, but is separate from the SDK route/contract alignment: the Server accepts the Session and Chat requests and starts the run.